### PR TITLE
[IMP] More compatible with 7.0 crm_claim_rma

### DIFF
--- a/crm_claim_code/README.rst
+++ b/crm_claim_code/README.rst
@@ -27,6 +27,7 @@ Contributors
 * Iker Coranti <ikercoranti@avanzosc.com>
 * Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
 * Alfredo de la Fuente <alfredodelafuente@avanzosc.es>
+* Ondřej Kuzník <ondrej.kuznik@credativ.co.uk>
 
 Maintainer
 ----------

--- a/crm_claim_code/__openerp__.py
+++ b/crm_claim_code/__openerp__.py
@@ -22,11 +22,12 @@
 
 {
     "name": "Sequential Code for Claims",
-    "version": "1.0",
+    "version": "8.0.1.1.0",
     "category": "Customer Relationship Management",
     "author": "OdooMRP team, "
               "AvanzOSC, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+              "credativ ltd., "
               "Odoo Community Association (OCA)",
     "website": "http://www.avanzosc.es",
     "license": "AGPL-3",

--- a/crm_claim_code/i18n/crm_claim_code.pot
+++ b/crm_claim_code/i18n/crm_claim_code.pot
@@ -27,6 +27,6 @@ msgstr ""
 
 #. module: crm_claim_code
 #: sql_constraint:crm.claim:0
-msgid "The code must be unique!"
+msgid "The code must be unique per Company!"
 msgstr ""
 

--- a/crm_claim_code/i18n/es.po
+++ b/crm_claim_code/i18n/es.po
@@ -27,6 +27,6 @@ msgstr "Número de reclamación"
 
 #. module: crm_claim_code
 #: sql_constraint:crm.claim:0
-msgid "The code must be unique!"
-msgstr "¡El número debe de ser único!"
+msgid "The code must be unique per Company!"
+msgstr "¡El número debe de ser único por compañía!"
 

--- a/crm_claim_code/models/crm_claim.py
+++ b/crm_claim_code/models/crm_claim.py
@@ -32,10 +32,12 @@ class CrmClaim(models.Model):
         return super(CrmClaim, self).copy(default)
 
     @api.multi
-    @api.depends('code', 'name')
+    @api.depends('code')
     def name_get(self):
+        orig_names = dict(super(CrmClaim, self).name_get())
+
         res = []
         for claim in self:
-            name = "[{0.code}] {0.name}".format(claim)
+            name = "[{}] {}".format(claim.code, orig_names[claim.id])
             res.append((claim.id, name))
         return res

--- a/crm_claim_code/models/crm_claim.py
+++ b/crm_claim_code/models/crm_claim.py
@@ -10,11 +10,12 @@ class CrmClaim(models.Model):
     _inherit = "crm.claim"
 
     code = fields.Char(
-        string='Claim Number', required=True, default="/", readonly=True)
+        string='Claim Number', required=True, default="/", readonly=True,
+        oldname='number')
 
     _sql_constraints = [
-        ('crm_claim_unique_code', 'UNIQUE (code)',
-         'The code must be unique!'),
+        ('crm_claim_unique_code', 'UNIQUE (code, company_id)',
+         'The code must be unique per Company!'),
     ]
 
     @api.model
@@ -29,3 +30,12 @@ class CrmClaim(models.Model):
             default = {}
         default['code'] = self.env['ir.sequence'].get('crm.claim')
         return super(CrmClaim, self).copy(default)
+
+    @api.multi
+    @api.depends('code', 'name')
+    def name_get(self):
+        res = []
+        for claim in self:
+            name = "[{0.code}] {0.name}".format(claim)
+            res.append((claim.id, name))
+        return res


### PR DESCRIPTION
To provide an upgrade path from crm_claim_rma from 7.0:
- The constraint needs to be relaxed to per company only
- `'number'` field used as fallback
- Provide `name_get()`
