### PR TITLE
FIX travis repositories dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,8 @@ virtualenv:
 install:
   - pip install unicodecsv
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
-  - git clone --depth=1 https://github.com/OCA/partner-contact.git ${HOME}/partner-contact  -b ${VERSION}
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
-# example: dependency
-  - git clone --depth=1 https://github.com/OCA/web -b ${VERSION} $HOME/web
 
 script:
   - travis_run_tests

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,2 @@
+partner-contact https://github.com/OCA/partner-contact.git
+web https://github.com/OCA/web.git


### PR DESCRIPTION
With latest maintainer-quality-tools changes, repositories should be loaded from oca_dependencies.txt file. 
This PR do that so that other PR can pass
