### PR TITLE
[FIX] Exception when scheduling a phonecall from another

### DIFF
--- a/crm_phonecall_summary_predefined/README.rst
+++ b/crm_phonecall_summary_predefined/README.rst
@@ -47,6 +47,7 @@ Contributors
 
 * Rafael Blasco <rafabn@antiun.com>
 * Jairo Llopis <yajo.sk8@gmail.com>
+* Antonio Espinosa <antonioea@antiun.com>
 
 Maintainer
 ----------

--- a/crm_phonecall_summary_predefined/__init__.py
+++ b/crm_phonecall_summary_predefined/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# © 2016 Antiun Ingeniería S.L. - Antonio  Espinosa
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/crm_phonecall_summary_predefined/models/__init__.py
+++ b/crm_phonecall_summary_predefined/models/__init__.py
@@ -2,4 +2,6 @@
 # © 2016 Antiun Ingeniería S.L. - Jairo Llopis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import crm_phonecall_summary
+from . import crm_phonecall2phonecall
 from . import crm_phonecall

--- a/crm_phonecall_summary_predefined/models/crm_phonecall.py
+++ b/crm_phonecall_summary_predefined/models/crm_phonecall.py
@@ -54,7 +54,6 @@ class CRMPhonecall(models.Model):
         res = super(CRMPhonecall, self)._prepare_another_phonecall_vals(
             call, schedule_time, call_summary, user_id=user_id,
             section_id=section_id, categ_id=categ_id)
-        summary_id = (self.env.context and
-                      self.env.context.get('summary_id', False) or False)
-        res['summary_id'] = summary_id
+        res['summary_id'] = self.env.context.get(
+            'summary_id', res.get('summary_id', False))
         return res

--- a/crm_phonecall_summary_predefined/models/crm_phonecall.py
+++ b/crm_phonecall_summary_predefined/models/crm_phonecall.py
@@ -48,7 +48,7 @@ class CRMPhonecall(models.Model):
                 s.summary_id = summary.search([("name", "=", s.name)])
 
     @api.model
-    def _prepare_another_phonecall(
+    def _prepare_another_phonecall_vals(
             self, call, schedule_time, call_summary, user_id=False,
             section_id=False, categ_id=False):
         res = super(CRMPhonecall, self)._prepare_another_phonecall(

--- a/crm_phonecall_summary_predefined/models/crm_phonecall.py
+++ b/crm_phonecall_summary_predefined/models/crm_phonecall.py
@@ -51,7 +51,7 @@ class CRMPhonecall(models.Model):
     def _prepare_another_phonecall_vals(
             self, call, schedule_time, call_summary, user_id=False,
             section_id=False, categ_id=False):
-        res = super(CRMPhonecall, self)._prepare_another_phonecall(
+        res = super(CRMPhonecall, self)._prepare_another_phonecall_vals(
             call, schedule_time, call_summary, user_id=user_id,
             section_id=section_id, categ_id=categ_id)
         summary_id = (self.env.context and

--- a/crm_phonecall_summary_predefined/models/crm_phonecall.py
+++ b/crm_phonecall_summary_predefined/models/crm_phonecall.py
@@ -47,16 +47,14 @@ class CRMPhonecall(models.Model):
             except IntegrityError:
                 s.summary_id = summary.search([("name", "=", s.name)])
 
-
-class CRMPhonecallSummary(models.Model):
-    _name = "crm.phonecall.summary"
-    _sql_constraints = [
-        ("name_unique", "UNIQUE (name)", "Name must be unique"),
-    ]
-
-    name = fields.Char()
-    phonecall_ids = fields.One2many(
-        "crm.phonecall",
-        "summary_id",
-        "Phonecalls",
-        help="Phonecalls with this summary.")
+    @api.model
+    def _prepare_another_phonecall(
+            self, call, schedule_time, call_summary, user_id=False,
+            section_id=False, categ_id=False):
+        res = super(CRMPhonecall, self)._prepare_another_phonecall(
+            call, schedule_time, call_summary, user_id=user_id,
+            section_id=section_id, categ_id=categ_id)
+        summary_id = (self.env.context and
+                      self.env.context.get('summary_id', False) or False)
+        res['summary_id'] = summary_id
+        return res

--- a/crm_phonecall_summary_predefined/models/crm_phonecall2phonecall.py
+++ b/crm_phonecall_summary_predefined/models/crm_phonecall2phonecall.py
@@ -5,7 +5,7 @@
 from openerp import api, fields, models
 
 
-class CRMPhonecall2Phonecall(models.Model):
+class CRMPhonecall2Phonecall(models.TransientModel):
     _inherit = "crm.phonecall2phonecall"
 
     name = fields.Char(

--- a/crm_phonecall_summary_predefined/models/crm_phonecall2phonecall.py
+++ b/crm_phonecall_summary_predefined/models/crm_phonecall2phonecall.py
@@ -8,16 +8,16 @@ from openerp import api, fields, models
 class CRMPhonecall2Phonecall(models.TransientModel):
     _inherit = "crm.phonecall2phonecall"
 
-    name = fields.Char(
-        related="summary_id.name",
-        store=True,
-        required=False,
-        readonly=True)
     summary_id = fields.Many2one(
         comodel_name="crm.phonecall.summary",
         string="Summary",
         required=True,
         ondelete="restrict")
+    name = fields.Char(
+        related="summary_id.name",
+        store=True,
+        required=False,
+        readonly=True)
 
     @api.model
     def default_get(self, fields):

--- a/crm_phonecall_summary_predefined/models/crm_phonecall2phonecall.py
+++ b/crm_phonecall_summary_predefined/models/crm_phonecall2phonecall.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingeniería S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+
+
+class CRMPhonecall2Phonecall(models.Model):
+    _inherit = "crm.phonecall2phonecall"
+
+    name = fields.Char(
+        related="summary_id.name",
+        store=True,
+        required=False,
+        readonly=True)
+    summary_id = fields.Many2one(
+        comodel_name="crm.phonecall.summary",
+        string="Summary",
+        required=True,
+        ondelete="restrict")
+
+    @api.model
+    def default_get(self, fields):
+        res = super(CRMPhonecall2Phonecall, self).default_get(fields)
+        record_id = (self.env.context and
+                     self.env.context.get('active_id', False) or False)
+        if record_id:
+            phonecall = self.env['crm.phonecall'].browse(record_id)
+            if 'summary_id' in fields:
+                res.update({'summary_id': phonecall.summary_id.id})
+        return res
+
+    def action_schedule(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        # Only consider first wizard, because in all cases there's only one
+        this = self.browse(cr, uid, ids, context=context)[0]
+        context['summary_id'] = this.summary_id.id
+        return super(CRMPhonecall2Phonecall, self).action_schedule(
+            cr, uid, ids, context=context)

--- a/crm_phonecall_summary_predefined/models/crm_phonecall_summary.py
+++ b/crm_phonecall_summary_predefined/models/crm_phonecall_summary.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class CRMPhonecallSummary(models.Model):
+    _name = "crm.phonecall.summary"
+    _sql_constraints = [
+        ("name_unique", "UNIQUE (name)", "Name must be unique"),
+    ]
+
+    name = fields.Char()
+    phonecall_ids = fields.One2many(
+        "crm.phonecall",
+        "summary_id",
+        "Phonecalls",
+        help="Phonecalls with this summary.")

--- a/crm_phonecall_summary_predefined/views/crm_phonecall_view.xml
+++ b/crm_phonecall_summary_predefined/views/crm_phonecall_view.xml
@@ -33,6 +33,20 @@
         </field>
     </record>
 
+    <record id="phonecall_to_phonecall_view" model="ir.ui.view">
+        <field name="name">Replace name by summary_id</field>
+        <field name="model">crm.phonecall2phonecall</field>
+        <field name="inherit_id" ref="crm.phonecall_to_phonecall_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="attributes">
+                <attribute name="invisible">True</attribute>
+            </xpath>
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="summary_id"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="crm_case_phone_calendar_view" model="ir.ui.view">
         <field name="name">Replace name by summary_id</field>
         <field name="model">crm.phonecall</field>


### PR DESCRIPTION
This PR fix a bug when scheduling a phonecall from another. Steps to reproduce:
1. Install addon 'crm_phonecall_summary_predefined'
2. Go to Sales > Logged phones and clean filters
3. Click at Phone icon (icons on the right in each call row) to 'Schedule Other Call'
4. Press 'Schedule Call' button

An IntegrityError is raised:

```
Integrity Error

The operation cannot be completed, probably due to the following:
- deletion: you may be trying to delete a record while other records still reference it
- creation/update: a mandatory field is not correctly set

[object with reference: summary_id - summary.id]
```

This PR adds summary_id field to `crm.phonecall2phonecall` model and view in order to create a new call with that field assigned and avoid integrity error.

This PR depends on these ones:
- https://github.com/OCA/OCB/pull/482
- https://github.com/odoo/odoo/pull/11791
