### PR TITLE
Fix creation of existing column

### DIFF
--- a/crm_claim_code/__init__.py
+++ b/crm_claim_code/__init__.py
@@ -9,10 +9,13 @@ from openerp import SUPERUSER_ID
 
 
 def create_code_equal_to_id(cr):
-    cr.execute('ALTER TABLE crm_claim '
-               'ADD COLUMN code character varying;')
-    cr.execute('UPDATE crm_claim '
-               'SET code = id;')
+    cr.execute("SELECT column_name FROM information_schema.columns "
+               "WHERE table_name = 'crm_claim' AND column_name = 'code'")
+    if not cr.fetchone():
+        cr.execute('ALTER TABLE crm_claim '
+                   'ADD COLUMN code character varying;')
+        cr.execute('UPDATE crm_claim '
+                   'SET code = id;')
 
 
 def assign_old_sequences(cr, registry):

--- a/crm_claim_code/__init__.py
+++ b/crm_claim_code/__init__.py
@@ -8,6 +8,9 @@ from openerp.api import Environment
 from openerp import SUPERUSER_ID
 
 
+new_field_code_added = False
+
+
 def create_code_equal_to_id(cr):
     cr.execute("SELECT column_name FROM information_schema.columns "
                "WHERE table_name = 'crm_claim' AND column_name = 'code'")
@@ -16,9 +19,14 @@ def create_code_equal_to_id(cr):
                    'ADD COLUMN code character varying;')
         cr.execute('UPDATE crm_claim '
                    'SET code = id;')
+        global new_field_code_added
+        new_field_code_added = True
 
 
 def assign_old_sequences(cr, registry):
+    if not new_field_code_added:
+        # the field was already existing before the installation of the addon
+        return
     with Environment.manage():
         env = Environment(cr, SUPERUSER_ID, {})
 


### PR DESCRIPTION
When a database already have this field, the module cannot be installed.
Now it only creates the code column if it doesn't exist yet.
