### PR TITLE
[FIX] only users beloning to group 'Deduplicate Contacts / Manually' should be able to merge partners from the partner list views (action 'Merge automatically')

### DIFF
--- a/crm_deduplicate_acl/wizards/partner_merge_view.xml
+++ b/crm_deduplicate_acl/wizards/partner_merge_view.xml
@@ -3,29 +3,30 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
 
 <openerp>
-<data>
+    <data>
 
-<record id="base_partner_merge_automatic_wizard_form" model="ir.ui.view">
-    <field name="name">Restrict automatic merge access</field>
-    <field name="model">base.partner.merge.automatic.wizard</field>
-    <field
-        name="inherit_id"
-        ref="crm.base_partner_merge_automatic_wizard_form"/>
-    <field name="arch" type="xml">
-        <xpath expr="//button[@name='automatic_process_cb']"
-               position="attributes">
-            <attribute name="groups">
-                crm_deduplicate_acl.group_automatically
-            </attribute>
-        </xpath>
-        <xpath expr="//button[@name='update_all_process_cb']"
-               position="attributes">
-            <attribute name="groups">
-                crm_deduplicate_acl.group_automatically
-            </attribute>
-        </xpath>
-    </field>
-</record>
+        <record id="base_partner_merge_automatic_wizard_form" model="ir.ui.view">
+            <field name="name">Restrict automatic merge access</field>
+            <field name="model">base.partner.merge.automatic.wizard</field>
+            <field
+                name="inherit_id"
+                ref="crm.base_partner_merge_automatic_wizard_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//button[@name='automatic_process_cb']"
+                       position="attributes">
+                    <attribute name="groups">crm_deduplicate_acl.group_automatically</attribute>
+                </xpath>
+                <xpath expr="//button[@name='update_all_process_cb']"
+                       position="attributes">
+                    <attribute name="groups">crm_deduplicate_acl.group_automatically</attribute>
+                </xpath>
+            </field>
+        </record>
 
-</data>
+        <act_window id="crm.action_partner_merge"
+                    res_model="base.partner.merge.automatic.wizard" src_model="res.partner"
+            target="new" multi="True" key2="client_action_multi"
+                    view_mode="form" name="Automatic Merge" groups="group_manually"/>
+
+    </data>
 </openerp>

--- a/crm_deduplicate_acl/wizards/partner_merge_view.xml
+++ b/crm_deduplicate_acl/wizards/partner_merge_view.xml
@@ -23,7 +23,9 @@
             </field>
         </record>
 
-        <act_window id="crm.action_partner_merge" groups="group_manually"/>
+        <record id="crm.action_partner_merge" model="ir.actions.act_window">
+            <field name="groups">group_manually</field>
+        </record>
 
     </data>
 </openerp>

--- a/crm_deduplicate_acl/wizards/partner_merge_view.xml
+++ b/crm_deduplicate_acl/wizards/partner_merge_view.xml
@@ -23,10 +23,7 @@
             </field>
         </record>
 
-        <act_window id="crm.action_partner_merge"
-                    res_model="base.partner.merge.automatic.wizard" src_model="res.partner"
-            target="new" multi="True" key2="client_action_multi"
-                    view_mode="form" name="Automatic Merge" groups="group_manually"/>
+        <act_window id="crm.action_partner_merge" groups="group_manually"/>
 
     </data>
 </openerp>

--- a/crm_deduplicate_acl/wizards/partner_merge_view.xml
+++ b/crm_deduplicate_acl/wizards/partner_merge_view.xml
@@ -20,7 +20,7 @@
         </record>
 
         <record id="crm.action_partner_merge" model="ir.actions.act_window">
-            <field name="groups">group_manually</field>
+            <field name="groups_id">group_manually</field>
         </record>
 
     </data>

--- a/crm_deduplicate_acl/wizards/partner_merge_view.xml
+++ b/crm_deduplicate_acl/wizards/partner_merge_view.xml
@@ -8,16 +8,12 @@
         <record id="base_partner_merge_automatic_wizard_form" model="ir.ui.view">
             <field name="name">Restrict automatic merge access</field>
             <field name="model">base.partner.merge.automatic.wizard</field>
-            <field
-                name="inherit_id"
-                ref="crm.base_partner_merge_automatic_wizard_form"/>
+            <field name="inherit_id" ref="crm.base_partner_merge_automatic_wizard_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//button[@name='automatic_process_cb']"
-                       position="attributes">
+                <xpath expr="//button[@name='automatic_process_cb']" position="attributes">
                     <attribute name="groups">crm_deduplicate_acl.group_automatically</attribute>
                 </xpath>
-                <xpath expr="//button[@name='update_all_process_cb']"
-                       position="attributes">
+                <xpath expr="//button[@name='update_all_process_cb']" position="attributes">
                     <attribute name="groups">crm_deduplicate_acl.group_automatically</attribute>
                 </xpath>
             </field>


### PR DESCRIPTION
Now any partner can merge partners from any partner tree view (such as 'Sales / Customers').

With this fix, a user will only be able to see the option 'Merge automatically' in the partners tree view if he belongs to group "Deduplicate Contacts / Manually"
