### PR TITLE
[FIX][mass_mailing_partner] Exclude opt_out.

### DIFF
--- a/mass_mailing_partner/README.rst
+++ b/mass_mailing_partner/README.rst
@@ -82,6 +82,7 @@ Contributors
 * Rafael Blasco <rafabn@antiun.com>
 * Antonio Espinosa <antonioea@antiun.com>
 * Javier Iniesta <javieria@antiun.com>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/mass_mailing_partner/README.rst
+++ b/mass_mailing_partner/README.rst
@@ -79,7 +79,7 @@ Contributors
 ------------
 
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-* Rafael Blasco <rafabn@antiun.com>
+* Rafael Blasco <rafael.blasco@tecnativa.com>
 * Antonio Espinosa <antonioea@antiun.com>
 * Javier Iniesta <javieria@antiun.com>
 * Jairo Llopis <jairo.llopis@tecnativa.com>

--- a/mass_mailing_partner/__openerp__.py
+++ b/mass_mailing_partner/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Link partners with mass-mailing",
-    "version": "8.0.3.0.0",
+    "version": "8.0.2.1.0",
     "author": "Tecnativa, "
               "Antiun Ingeniería S.L., "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "

--- a/mass_mailing_partner/__openerp__.py
+++ b/mass_mailing_partner/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Link partners with mass-mailing",
-    "version": "8.0.2.0.0",
+    "version": "8.0.3.0.0",
     "author": "Tecnativa, "
               "Antiun Ingeniería S.L., "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "

--- a/mass_mailing_partner/models/res_partner.py
+++ b/mass_mailing_partner/models/res_partner.py
@@ -36,7 +36,8 @@ class ResPartner(models.Model):
                   "mailing lists. Email must be assigned." % self.name))
 
     @api.one
-    @api.depends('mass_mailing_contact_ids')
+    @api.depends('mass_mailing_contact_ids',
+                 'mass_mailing_contact_ids.opt_out')
     def _compute_mass_mailing_contacts_count(self):
         self.mass_mailing_contacts_count = len(self.mass_mailing_contact_ids)
 

--- a/mass_mailing_partner/models/res_partner.py
+++ b/mass_mailing_partner/models/res_partner.py
@@ -12,8 +12,10 @@ from openerp.exceptions import ValidationError
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    mass_mailing_contacts = fields.One2many(
+    mass_mailing_contact_ids = fields.One2many(
         string="Mailing lists",
+        oldname="mass_mailing_contacts",
+        domain=[('opt_out', '=', False)],
         comodel_name='mail.mass_mailing.contact', inverse_name='partner_id')
     mass_mailing_contacts_count = fields.Integer(
         string='Mailing list number',
@@ -28,15 +30,15 @@ class ResPartner(models.Model):
     @api.one
     @api.constrains('email')
     def _check_email_mass_mailing_contacts(self):
-        if self.mass_mailing_contacts and not self.email:
+        if self.mass_mailing_contact_ids and not self.email:
             raise ValidationError(
                 _("This partner '%s' is subscribed to one or more "
                   "mailing lists. Email must be assigned." % self.name))
 
     @api.one
-    @api.depends('mass_mailing_contacts')
+    @api.depends('mass_mailing_contact_ids')
     def _compute_mass_mailing_contacts_count(self):
-        self.mass_mailing_contacts_count = len(self.mass_mailing_contacts)
+        self.mass_mailing_contacts_count = len(self.mass_mailing_contact_ids)
 
     @api.one
     @api.depends('mass_mailing_stats')
@@ -52,5 +54,5 @@ class ResPartner(models.Model):
                 mm_vals['name'] = vals['name']
             if vals.get('email'):
                 mm_vals['name'] = vals['email']
-            self.mapped('mass_mailing_contacts').write(mm_vals)
+            self.mapped('mass_mailing_contact_ids').write(mm_vals)
         return res

--- a/mass_mailing_partner/models/res_partner.py
+++ b/mass_mailing_partner/models/res_partner.py
@@ -54,5 +54,7 @@ class ResPartner(models.Model):
                 mm_vals['name'] = vals['name']
             if vals.get('email'):
                 mm_vals['name'] = vals['email']
-            self.mapped('mass_mailing_contact_ids').write(mm_vals)
+            self.env["mail.mass_mailing.contact"].search([
+                ("partner_id", "in", self.ids),
+            ]).write(mm_vals)
         return res

--- a/mass_mailing_partner/views/res_partner_view.xml
+++ b/mass_mailing_partner/views/res_partner_view.xml
@@ -44,8 +44,8 @@
     <field name="priority">20</field>
     <field name="arch" type="xml">
         <field name="category_id" position="after">
-            <field name="mass_mailing_contacts" string="Mailing List"
-                filter_domain="[('mass_mailing_contacts.list_id','ilike', self)]"/>
+            <field name="mass_mailing_contact_ids" string="Mailing List"
+                filter_domain="[('mass_mailing_contact_ids.list_id','ilike', self)]"/>
         </field>
     </field>
 </record>


### PR DESCRIPTION
Now opted-out records will not be counted in the "Mailing lists" smart button
in the partner form.

@Tecnativa
