### PR TITLE
[IMP] rename table instead of copying

### DIFF
--- a/lettermgmt/migrations/8.0.2.0/post-migration.py
+++ b/lettermgmt/migrations/8.0.2.0/post-migration.py
@@ -20,22 +20,7 @@ def migrate(cr, version):
     # Rename column 'type' to 'type_id'
     cr.execute("""UPDATE res_letter SET type_id = type""")
 
-    # Rename model 'letter.class' to 'letter.category'
-    cr.execute("""INSERT INTO letter_category SELECT * FROM letter_class""")
-    cr.execute("""UPDATE ir_model_fields SET relation = 'letter.category'
-                  WHERE relation = 'letter.class'""")
-    cr.execute("""UPDATE ir_model_fields SET model = 'letter.category'
-                  WHERE model = 'letter.class'""")
-    cr.execute("""UPDATE ir_model_data SET model = 'letter.category'
-                  WHERE model = 'letter.class'""")
-    cr.execute("""UPDATE ir_attachment SET res_model = 'letter.category'
-                  WHERE res_model = 'letter.class'""")
-
     # Cleanup
     cr.execute("""ALTER TABLE res_letter DROP COLUMN snd_rec_date""")
     cr.execute("""ALTER TABLE res_letter DROP COLUMN type""")
     cr.execute("""ALTER TABLE res_letter DROP COLUMN class""")
-    cr.execute("""DROP INDEX IF EXISTS res_letter_snd_rec_date_index""")
-    cr.execute("""DROP INDEX IF EXISTS res_letter_type_index""")
-    cr.execute("""DROP INDEX IF EXISTS res_letter_class_index""")
-    cr.execute("""DROP TABLE letter_class""")

--- a/lettermgmt/migrations/8.0.2.0/pre-migration.py
+++ b/lettermgmt/migrations/8.0.2.0/pre-migration.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016 Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    if version is None:
+        return
+
+    # Rename model 'letter.class' to 'letter.category'
+    cr.execute("""ALTER TABLE letter_class RENAME TO letter_category""")
+    cr.execute("""UPDATE ir_model_fields SET relation = 'letter.category'
+                  WHERE relation = 'letter.class'""")
+    cr.execute("""UPDATE ir_model_fields SET model = 'letter.category'
+                  WHERE model = 'letter.class'""")
+    cr.execute("""UPDATE ir_model_data SET model = 'letter.category'
+                  WHERE model = 'letter.class'""")
+    cr.execute("""UPDATE ir_attachment SET res_model = 'letter.category'
+                  WHERE res_model = 'letter.class'""")


### PR DESCRIPTION
In https://github.com/OCA/crm/pull/87#issuecomment-247669240, @ivantodorovich talked about this issue, but we didn't followup on it. We really need to rename the table instead of selecting stuff, because otherwise things go very wrong when other modules add columns. Also, we can't assume that column order in both tables is the same.

Further, we don't need to drop the indices as they'll be dropped automatically when the corresponding column is dropped.