### PR TITLE
[10.0] [ADD] Crm lead followers

### DIFF
--- a/crm_lead_followers/README.rst
+++ b/crm_lead_followers/README.rst
@@ -1,0 +1,84 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==========================
+Share leads with followers
+==========================
+
+It's sometimes useful to share leads with some users that would normally not have
+access to them, e.g. developers for a service company so that can see and offer
+their input in possibile future projects they'll have to work on.
+Unfortunately the default access level on the CRM and Sale applications do not
+allow for this: either a user can see all leads, or he can see only his own
+leads, there is no way to "share" leads with non-sale users.
+
+This module solves this by extending the permissions of the CRM module so that users
+can be put in a group where they have (read or write) access only on leads that
+were explicitly shared with them (by adding them as followers).
+
+Configuration
+=============
+
+This module defines two additional access levels for the sale/crm application:
+
+* See Shared Leads: users in this groups can see leads where they have been added as followers
+* Edit Shared Leads: users in this groups can see and edit leads where they have been added as followers
+
+Neither of these groups give the user the permission to create or delete leads, nor they impact
+permissions on sale orders and quotations.
+Users of the group 'Sale / Own Documents Only' are automatically added to the 'Edit Shared Leads' group,
+that means that they will be automatically able to edit leads they are following.
+
+
+Usage
+=====
+
+Add the users to the followers of the leads you want them to be able to see/edit
+(according to the group you put them in).
+
+Known issues / Roadmap
+======================
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/crm/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Leonardo Donelli @ MONK Software <leonardo.donelli@monksoftware.it>
+
+Funders
+-------
+
+The development of this module has been financially supported by:
+
+* MONK Software
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/crm_lead_followers/__manifest__.py
+++ b/crm_lead_followers/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2017 Leonardo Donelli @ MONK Software <leonardo.donelli@monksoftware.it>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Share leads with followers',
+    'version': '10.0.1.0.0',
+    'license': 'AGPL-3',
+    'category': 'Sales',
+    'author': "MONK Software, Odoo Community Association",
+    'summary': "Add users as followers on a lead to share it with them",
+    'website': 'http://www.wearemonk.com',
+    'depends': ['crm', 'sale_crm'],
+    'data': [
+        'security/crm_lead_followers_security.xml',
+        'security/ir.model.access.csv',
+        'views/sales_team.xml',
+    ],
+    'installable': True,
+}

--- a/crm_lead_followers/__manifest__.py
+++ b/crm_lead_followers/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Share leads with followers',
-    'version': '10.0.1.2.0',
+    'version': '10.0.1.3.0',
     'license': 'AGPL-3',
     'category': 'Sales',
     'author': "MONK Software, Odoo Community Association",

--- a/crm_lead_followers/__manifest__.py
+++ b/crm_lead_followers/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Share leads with followers',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
     'category': 'Sales',
     'author': "MONK Software, Odoo Community Association",

--- a/crm_lead_followers/__manifest__.py
+++ b/crm_lead_followers/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Share leads with followers',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.2.0',
     'license': 'AGPL-3',
     'category': 'Sales',
     'author': "MONK Software, Odoo Community Association",
@@ -15,6 +15,7 @@
         'security/crm_lead_followers_security.xml',
         'security/ir.model.access.csv',
         'views/sales_team.xml',
+        'views/crm.xml',
     ],
     'installable': True,
 }

--- a/crm_lead_followers/security/crm_lead_followers_security.xml
+++ b/crm_lead_followers/security/crm_lead_followers_security.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="group_see_shared_leads" model="res.groups">
+    <field name="name">See Shared Leads</field>
+    <field name="category_id" ref="base.module_category_sales_management"/>
+  </record>
+
+  <record id="group_edit_shared_leads" model="res.groups">
+    <field name="name">Edit Shared Leads</field>
+    <field name="category_id" ref="base.module_category_sales_management"/>
+    <field name="implied_ids" eval="[(4, ref('crm_lead_followers.group_see_shared_leads'))]"/>
+  </record>
+
+  <record id="sales_team.group_sale_salesman" model="res.groups">
+    <field name="implied_ids" eval="[(4, ref('crm_lead_followers.group_edit_shared_leads'))]"/>
+  </record>
+
+  <record id="crm_lead_rule_see_shared_leads" model="ir.rule">
+    <field name="name">See followed Leads</field>
+    <field name="model_id" ref="crm.model_crm_lead"/>
+    <field name="domain_force">[('message_partner_ids','in',[user.partner_id.id])]</field>
+    <field name="groups" eval="[(4, ref('group_see_shared_leads'))]"/>
+  </record>
+
+  <record id="crm_lead_rule_edit_shared_leads" model="ir.rule">
+    <field name="name">Edit followed Leads</field>
+    <field name="model_id" ref="crm.model_crm_lead"/>
+    <field name="domain_force">[('message_partner_ids','in',[user.partner_id.id])]</field>
+    <field name="groups" eval="[(4, ref('group_edit_shared_leads'))]"/>
+  </record>
+
+</odoo>

--- a/crm_lead_followers/security/crm_lead_followers_security.xml
+++ b/crm_lead_followers/security/crm_lead_followers_security.xml
@@ -4,6 +4,7 @@
   <record id="group_see_shared_leads" model="res.groups">
     <field name="name">See Shared Leads</field>
     <field name="category_id" ref="base.module_category_sales_management"/>
+    <field name="implied_ids" eval="[(4, ref('crm.group_use_lead'))]"/>
   </record>
 
   <record id="group_edit_shared_leads" model="res.groups">

--- a/crm_lead_followers/security/ir.model.access.csv
+++ b/crm_lead_followers/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_crm_lead_see_shared_leads,crm.lead.see.shared.leads,crm.model_crm_lead,group_see_shared_leads,1,0,0,0
+access_crm_lead_edit_shared_leads,crm.lead.edit.shared.leads,crm.model_crm_lead,group_edit_shared_leads,1,1,0,0

--- a/crm_lead_followers/views/crm.xml
+++ b/crm_lead_followers/views/crm.xml
@@ -12,4 +12,13 @@
     </field>
   </record>
 
+  <!--
+      Restrict view modifications introduced by sale_crm to users of sales_team.group_sale_salesman
+      so that we don't get access error when trying to see a lead,
+      as we don't have permissions to access the sale.order model
+  -->
+  <record id="sale_crm.crm_case_form_view_oppor" model="ir.ui.view">
+    <field name="groups_id" eval="[(6, 0, [ref('sales_team.group_sale_salesman')])]"/>
+  </record>
+
 </odoo>

--- a/crm_lead_followers/views/crm.xml
+++ b/crm_lead_followers/views/crm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="crm_lead_view_search" model="ir.ui.view">
+    <field name="name">lead search view: add shared leads to my opportunities</field>
+    <field name="model">crm.lead</field>
+    <field name="inherit_id" ref="crm.view_crm_case_opportunities_filter"/>
+    <field name="arch" type="xml">
+      <filter name="assigned_to_me" position="attributes">
+        <attribute name="domain">['|', ('user_id', '=', uid), ('message_is_follower', '=', True)]</attribute>
+      </filter>
+    </field>
+  </record>
+
+</odoo>

--- a/crm_lead_followers/views/sales_team.xml
+++ b/crm_lead_followers/views/sales_team.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="sales_team.menu_base_partner" model="ir.ui.menu">
+    <field name="groups_id" eval="[(4, ref('group_see_shared_leads'))]"/>
+    <field name="name">Sales</field>
+  </record>
+
+  <!-- Hide menus -->
+  <record id="sale.menu_product_template_action" model="ir.ui.menu">
+    <field name="name">Products</field>
+    <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+  </record>
+
+  <record id="sales_team.menu_sales_team_act" model="ir.ui.menu">
+    <field name="name">Dashboard</field>
+    <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+  </record>
+
+  <record id="crm_lead_form_view_remove_order_button" model="ir.ui.view">
+    <field name="name">lead form view: remove orders button for shared leads users</field>
+    <field name="model">crm.lead</field>
+    <field name="inherit_id" ref="sale_crm.crm_case_form_view_oppor"/>
+    <field name="arch" type="xml">
+      <!-- Remove order buttons so that we don't have to give ACL access to sale.order -->
+      <xpath expr="//div[@name='button_box']" position="replace">
+        <!-- need to redefine this field which was defined in the button box, used in a filter -->
+        <field name="active" invisible="1"/>
+      </xpath>
+    </field>
+  </record>
+
+</odoo>

--- a/crm_lead_followers/views/sales_team.xml
+++ b/crm_lead_followers/views/sales_team.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+  <!-- Add access to the top Sales menu to member of shared leads groups -->
   <record id="sales_team.menu_base_partner" model="ir.ui.menu">
     <field name="groups_id" eval="[(4, ref('group_see_shared_leads'))]"/>
     <field name="name">Sales</field>
@@ -15,19 +16,6 @@
   <record id="sales_team.menu_sales_team_act" model="ir.ui.menu">
     <field name="name">Dashboard</field>
     <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
-  </record>
-
-  <record id="crm_lead_form_view_remove_order_button" model="ir.ui.view">
-    <field name="name">lead form view: remove orders button for shared leads users</field>
-    <field name="model">crm.lead</field>
-    <field name="inherit_id" ref="sale_crm.crm_case_form_view_oppor"/>
-    <field name="arch" type="xml">
-      <!-- Remove order buttons so that we don't have to give ACL access to sale.order -->
-      <xpath expr="//div[@name='button_box']" position="replace">
-        <!-- need to redefine this field which was defined in the button box, used in a filter -->
-        <field name="active" invisible="1"/>
-      </xpath>
-    </field>
   </record>
 
 </odoo>


### PR DESCRIPTION

# Share leads with followers

It's sometimes useful to share leads with some users that would normally not have
access to them, e.g. developers for a service company so that can see and offer
their input in possibile future projects they'll have to work on.
Unfortunately the default access level on the CRM and Sale applications do not
allow for this: either a user can see all leads, or he can see only his own
leads, there is no way to "share" leads with non-sale users.

This module solves this by extending the permissions of the CRM module so that users
can be put in a group where they have (read or write) access only on leads that
were explicitly shared with them (by adding them as followers).