### PR TITLE
[8.0][FIX] crm_action error default value in company_id field

### DIFF
--- a/crm_action/README.rst
+++ b/crm_action/README.rst
@@ -59,6 +59,7 @@ Contributors
 * Jordi RIERA <jordi.riera@savoirfairelinux.com>
 * Bruno JOLIVEAU <bruno.joliveau@savoirfairelinux.com>
 * Alexis de Lattre <alexis.delattre@akretion.com>
+* Kiko Peiro <francisco.peiro@factorlibre.com>
 
 Maintainer
 ----------

--- a/crm_action/models/crm_action.py
+++ b/crm_action/models/crm_action.py
@@ -26,8 +26,8 @@ class CrmAction(models.Model):
 
     company_id = fields.Many2one(
         'res.company', string='Company',
-        default=lambda self: self.env['res.company']._company_default_get(
-            'crm.action'))
+        default=lambda self: self.env['res.company'].browse(
+            self.env['res.company']._company_default_get('crm.action')))
 
     partner_id = fields.Many2one(
         'res.partner', string='Customer')


### PR DESCRIPTION
New default value on field company_id causes module update error when the field is not created on database

Related https://github.com/OCA/crm/issues/103

Traceback (most recent call last):
  File "/opt/odoo_proclub/shared/odoo-server/openerp/service/server.py", line 941, in preload_registries
    registry = RegistryManager.new(dbname, update_module=update_module)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/modules/registry.py", line 370, in new
    openerp.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/modules/loading.py", line 350, in load_modules
    force, status, report, loaded_modules, update_module)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/modules/loading.py", line 255, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/modules/loading.py", line 157, in load_module_graph
    init_module_models(cr, package.name, models)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/modules/module.py", line 286, in init_module_models
    result = obj._auto_init(cr, {'module': module_name})
  File "/opt/odoo_proclub/shared/odoo-server/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/models.py", line 2643, in _auto_init
    self._set_default_value_on_column(cr, k, context=context)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/models.py", line 2405, in _set_default_value_on_column
    default = default(self, cr, SUPERUSER_ID, context)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/api.py", line 372, in old_api
    result = method(recs, *args, **kwargs)
  File "/opt/odoo_proclub/shared/odoo-server/openerp/fields.py", line 432, in <lambda>
    lambda recs: self.convert_to_write(value(recs))
  File "/opt/odoo_proclub/shared/odoo-server/openerp/fields.py", line 1607, in convert_to_write
    return value.id
AttributeError: 'int' object has no attribute 'id'