### PR TITLE
[10.0][ADD] calendar_resource: Add further resource validations.

### DIFF
--- a/calendar_resource/README.rst
+++ b/calendar_resource/README.rst
@@ -10,11 +10,26 @@ This module adds new features to facilitate resource management with meetings:
 
 * To attach resources to a meeting, go to `Calendar` => Click on a meeting => `Edit` =>
   `Edit` => add any related resources.
-* To edit or add a resource, go to `Settings` => `Resource` => `Resources`.
+* To edit or add a resource, go to `Settings` => `Resource` => `Resources`. Developer mode
+  has to be enabled for this menu to show.
 * This module can also prevent resources from being double-booked. Go to a resource
   and disable `Allow Double Booking` (this is enabled by default). As a note, the same
-  resource in a meeting that ends at 5pm and also in a meeting that starts at 5pm on the same day
+  resource in a meeting that ends at 5pm and in a meeting that starts at 5pm on the same day
   would not not be considered double-booked.
+* You can restrict resources to certain calendar types. In the Resources form view, edit the
+  `Event Types` field. The resource can then be added to events only of those types.
+* Resources cannot be added to events when they're not available, either because they're on leave
+  or because the event time is outside their working time.
+* If you have an event selected as `allday`, only if there are no working times available
+  on 1 or more of the days in that event will an error be raised. For example, if you set
+  an event to `allday` on a Saturday and there are no working times at all that Saturday
+  for a particular resource, then an error will be raised. However, if there is at least
+  1 working time interval for that resource on the Saturday, regardless of how long or
+  short that working time is, the day will be considered covered by that working time.
+  If the event is not allday, any time the resource is not available during the event,
+  regardless of the time of day, will cause an error to be raised.
+* To stop leaves and working time validations on a resource when adding to an event,
+  set the resource's `Working Time` field to blank in Settings.
 
 Usage
 =====
@@ -23,14 +38,11 @@ Usage
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/111/10.0
 
-Known Issues / Roadmap
-======================
+Roadmap
+=======
 
-* Tie resources into calendar types (calendar.event.type), where certain resources are available
-  only with certain calendar types.
-* Add a calendar view on resources, so resources such as a room can be seen if available.
-* Validate Resource Leaves to avoid appointments for dates where the resource is not available.
-* Validate Resource Calendar, to avoid appointments for times outside their availability.
+* Abstract out logic from _check_resource_ids_working_times into separate methods in
+  resource.calendar.
 
 Bug Tracker
 ===========

--- a/calendar_resource/README.rst
+++ b/calendar_resource/README.rst
@@ -10,10 +10,9 @@ This module adds new features to facilitate resource management with meetings:
 
 * To attach resources to a meeting, go to `Calendar` => Click on a meeting => `Edit` =>
   `Edit` => add any related resources.
-* To edit or add a resource, go to `Settings` => `Resource` => `Resources`. Developer mode
-  has to be enabled for this menu to show.
+* To edit or add a resource, go to `Calendar` => `Resources` => `Resources`.
 * This module can also prevent resources from being double-booked. Go to a resource
-  and disable `Allow Double Booking` (this is enabled by default). As a note, the same
+  and disable or enable `Allow Double Booking` (this is disabled by default). As a note, the same
   resource in a meeting that ends at 5pm and in a meeting that starts at 5pm on the same day
   would not not be considered double-booked.
 * You can restrict resources to certain calendar types. In the Resources form view, edit the
@@ -26,10 +25,10 @@ This module adds new features to facilitate resource management with meetings:
   for a particular resource, then an error will be raised. However, if there is at least
   1 working time interval for that resource on the Saturday, regardless of how long or
   short that working time is, the day will be considered covered by that working time.
-  If the event is not allday, any time the resource is not available during the event,
+  If the event is not `allday`, any time the resource is not available during the event,
   regardless of the time of day, will cause an error to be raised.
 * To stop leaves and working time validations on a resource when adding to an event,
-  set the resource's `Working Time` field to blank in Settings.
+  set the resource's `Working Time` field to blank in the resource form view.
 
 Usage
 =====

--- a/calendar_resource/__manifest__.py
+++ b/calendar_resource/__manifest__.py
@@ -9,7 +9,7 @@
     "version": "10.0.1.1.0",
     "category": "CRM",
     "website": "http://www.savoirfairelinux.com",
-    "author": "Savoir-faire Linux, Laslabs, Odoo Community Association (OCA)",
+    "author": "Savoir-faire Linux, LasLabs, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/calendar_resource/__manifest__.py
+++ b/calendar_resource/__manifest__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2010-2014 Savoir-faire Linux
-# Copryight 2017 Laslabs Inc.
+# Copyright 2017 Laslabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
@@ -18,8 +18,11 @@
         "calendar",
     ],
     "data": [
+        "security/resource_security.xml",
+        "security/ir.model.access.csv",
         "views/calendar_event_view.xml",
         "views/resource_resource_view.xml",
+        "views/calendar_menu.xml",
     ],
     "demo": [
         "demo/resource_resource_demo.xml",

--- a/calendar_resource/__manifest__.py
+++ b/calendar_resource/__manifest__.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright 2010-2014 Savoir-faire Linux
+# Copryight 2017 Laslabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Calendar Resources",
     "summary": "New features to facilitate resource management with meetings.",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.1.0",
     "category": "CRM",
     "website": "http://www.savoirfairelinux.com",
     "author": "Savoir-faire Linux, Laslabs, Odoo Community Association (OCA)",
@@ -19,5 +20,10 @@
     "data": [
         "views/calendar_event_view.xml",
         "views/resource_resource_view.xml",
+    ],
+    "demo": [
+        "demo/resource_resource_demo.xml",
+        "demo/resource_calendar.xml",
+        "demo/resource_calendar_attendance.xml",
     ],
 }

--- a/calendar_resource/__manifest__.py
+++ b/calendar_resource/__manifest__.py
@@ -8,7 +8,7 @@
     "summary": "New features to facilitate resource management with meetings.",
     "version": "10.0.1.1.0",
     "category": "CRM",
-    "website": "http://www.savoirfairelinux.com",
+    "website": "https://github.com/OCA/crm",
     "author": "Savoir-faire Linux, LasLabs, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,

--- a/calendar_resource/demo/resource_calendar.xml
+++ b/calendar_resource/demo/resource_calendar.xml
@@ -5,7 +5,7 @@
 <odoo>
 
     <record id="resource_calendar_1" model="resource.calendar">
-        <field name="name">Calendar Resource Demo Calendar</field>
+        <field name="name">Resource Demo Calendar</field>
     </record>
 
 </odoo>

--- a/calendar_resource/demo/resource_calendar.xml
+++ b/calendar_resource/demo/resource_calendar.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 LasLabs Inc.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record id="resource_calendar_1" model="resource.calendar">
+        <field name="name">Calendar Resource Demo Calendar</field>
+    </record>
+
+</odoo>

--- a/calendar_resource/demo/resource_calendar_attendance.xml
+++ b/calendar_resource/demo/resource_calendar_attendance.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 LasLabs Inc.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record id="resource_calendar_attendance_1" model="resource.calendar.attendance">
+        <field name="name">Interval 1</field>
+        <field name="dayofweek">1</field>
+        <field name="hour_from" eval="12" />
+        <field name="hour_to" eval="20" />
+        <field name="calendar_id" ref="resource_calendar_1" />
+    </record>
+
+    <record id="resource_calendar_attendance_2" model="resource.calendar.attendance">
+        <field name="name">Interval 2</field>
+        <field name="dayofweek">1</field>
+        <field name="hour_from" eval="20" />
+        <field name="hour_to" eval="23.9997" />
+        <field name="calendar_id" ref="resource_calendar_1" />
+    </record>
+
+    <record id="resource_calendar_attendance_3" model="resource.calendar.attendance">
+        <field name="name">Interval 3</field>
+        <field name="dayofweek">2</field>
+        <field name="hour_from" eval="5" />
+        <field name="hour_to" eval="11.5" />
+        <field name="calendar_id" ref="resource_calendar_1" />
+    </record>
+
+    <record id="resource_calendar_attendance_4" model="resource.calendar.attendance">
+        <field name="name">Interval 4</field>
+        <field name="dayofweek">1</field>
+        <field name="hour_from" eval="0" />
+        <field name="hour_to" eval="16" />
+        <field name="calendar_id" ref="resource_calendar_1" />
+    </record>
+
+    <record id="resource_calendar_attendance_5" model="resource.calendar.attendance">
+        <field name="name">Interval 5</field>
+        <field name="dayofweek">3</field>
+        <field name="hour_from" eval="9" />
+        <field name="hour_to" eval="23.984" />
+        <field name="calendar_id" ref="resource_calendar_1" />
+    </record>
+
+    <record id="resource_calendar_attendance_6" model="resource.calendar.attendance">
+        <field name="name">Interval 6</field>
+        <field name="dayofweek">2</field>
+        <field name="hour_from" eval="0" />
+        <field name="hour_to" eval="12" />
+        <field name="calendar_id" ref="resource_calendar_1" />
+    </record>
+
+</odoo>

--- a/calendar_resource/demo/resource_calendar_attendance.xml
+++ b/calendar_resource/demo/resource_calendar_attendance.xml
@@ -48,7 +48,7 @@
         <field name="name">Interval 6</field>
         <field name="dayofweek">2</field>
         <field name="hour_from" eval="0" />
-        <field name="hour_to" eval="12" />
+        <field name="hour_to" eval="16" />
         <field name="calendar_id" ref="resource_calendar_1" />
     </record>
 

--- a/calendar_resource/demo/resource_resource_demo.xml
+++ b/calendar_resource/demo/resource_resource_demo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 LasLabs Inc.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record id="resource.resource_analyst" model="resource.resource">
+        <field name="allowed_event_types"
+               eval="[(6, 0, [ref('calendar.categ_meet1'),
+                              ref('calendar.categ_meet2'),
+                              ref('calendar.categ_meet3'),
+                              ref('calendar.categ_meet4'),
+                              ref('calendar.categ_meet5')])]"
+                              />
+    </record>
+
+    <record id="resource.resource_designer" model="resource.resource">
+        <field name="allowed_event_types"
+               eval="[(6, 0, [ref('calendar.categ_meet1'),
+                              ref('calendar.categ_meet2'),
+                              ref('calendar.categ_meet3'),
+                              ref('calendar.categ_meet4')])]"
+                              />
+    </record>
+
+    <record id="resource.resource_developer" model="resource.resource">
+        <field name="allowed_event_types"
+               eval="[(6, 0, [ref('calendar.categ_meet1'),
+                              ref('calendar.categ_meet2'),
+                              ref('calendar.categ_meet3'),
+                              ref('calendar.categ_meet4')])]"
+                              />
+    </record>
+
+</odoo>

--- a/calendar_resource/models/__init__.py
+++ b/calendar_resource/models/__init__.py
@@ -2,5 +2,8 @@
 # Copyright 2014 Therp BV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import calendar_event_type
 from . import calendar_event
+from . import resource_calendar_attendance
+from . import resource_calendar
 from . import resource_resource

--- a/calendar_resource/models/__init__.py
+++ b/calendar_resource/models/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014 Therp BV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import calendar_event_type

--- a/calendar_resource/models/calendar_event.py
+++ b/calendar_resource/models/calendar_event.py
@@ -3,6 +3,8 @@
 # Copryight 2017 Laslabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from datetime import datetime, time, timedelta
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -16,10 +18,88 @@ class CalendarEvent(models.Model):
         comodel_name='resource.resource',
     )
 
-    @api.constrains('resource_ids')
-    def _check_resource_ids_dbl_book(self):
+    @api.model
+    def _format_datetime_interval_list(self, intervals):
+        """ Converts intervals to string values for front-end
+            display purposes, taking into account language,
+            timezone, as well as date and time formats.
+
+        Example:
+
+            .. code-block python
+
+            self._format_datetime_interval_list(
+                intervals=[
+                    (
+                        datetime(2017, 6, 28, 17, 0, 0),
+                        datetime(2017, 6, 29, 8, 0, 0),
+                    ),
+                    (
+                        datetime(2017, 6, 29, 12, 0, 0),
+                        datetime(2017, 6, 29, 13, 0, 0),
+                    ),
+                ],
+            )
+
+            The above example will output the following string,
+            depending on date and time format, as well as timezone.
+
+            \n06/28/2017 at 17:00:00 To\n
+            06/29/2017 at 08:00:00 (UTC)\n
+
+            \n06/29/2017 at 12:00:00 To\n
+            06/29/2017 at 13:00:00 (UTC)\n
+
+        """
+        datetimes = ''
+        for interval in intervals:
+            if not isinstance(interval[0], str):
+                interval = (
+                    fields.Datetime.to_string(interval[0]),
+                    fields.Datetime.to_string(interval[1]),
+                )
+            args = {
+                'start': interval[0],
+                'stop': interval[1],
+                'zallday': False,
+                'zduration': 24,
+            }
+            datetimes += '\n%s\n' % self._get_display_time(**args)
+        return datetimes
+
+    @api.multi
+    def _event_in_past(self):
+        self.ensure_one()
+        stop_datetime = fields.Datetime.from_string(self.stop)
+        now_datetime = fields.Datetime.from_string(fields.Datetime.now())
+        return stop_datetime < now_datetime
+
+    @api.multi
+    def _get_event_date_list(self):
+        self.ensure_one()
+        start = fields.Date.from_string(self.start)
+        stop = fields.Datetime.from_string(self.stop)
+
+        if stop.time() == time(0, 0):
+            stop -= timedelta(days=1)
+
+        stop = stop.date()
+        date = start
+        dates = []
+        while date <= stop:
+            dates.append(date)
+            date += timedelta(days=1)
+
+        return dates
+
+    @api.multi
+    @api.constrains('resource_ids', 'start', 'stop')
+    def _check_resource_ids_double_book(self):
         """ Check Double Booking """
         for record in self:
+
+            if record._event_in_past():
+                continue
 
             resources = record.resource_ids.filtered(
                 lambda s: s.allow_double_book is False
@@ -34,12 +114,141 @@ class CalendarEvent(models.Model):
                 ('stop', '>', record.start),
             ])
 
-            for overlap in overlaps:
-                for resource in resources:
+            for resource in overlaps.mapped(lambda s: s.resource_ids):
+                raise ValidationError(
+                    _(
+                        'The resource, %s, cannot be double-booked '
+                        'with any overlapping meetings or events.'
+                    )
+                    % resource.name,
+                )
 
-                    if resource in overlap.resource_ids:
-                        raise ValidationError(_(
-                            'The resource, %s, cannot be double-booked '
-                            'with any overlapping meetings or events.'
-                            % resource.name,
-                        ))
+    @api.multi
+    @api.constrains('resource_ids', 'categ_ids')
+    def _check_resource_ids_categ_ids(self):
+
+        for record in self:
+
+            if record._event_in_past():
+                continue
+
+            if not record.categ_ids:
+                return
+
+            for resource in record.resource_ids:
+                categs = record.categ_ids.filtered(
+                    lambda s: s not in resource.allowed_event_types
+                )
+                if categs:
+                    raise ValidationError(
+                        _(
+                            "The resource, '%s', is not allowed in the "
+                            "following event types: \n%s"
+                        )
+                        % (
+                            resource.name,
+                            ', '.join([
+                                categ.name for categ in categs
+                            ]),
+                        )
+                    )
+
+    @api.multi
+    @api.constrains('resource_ids', 'start', 'stop')
+    def _check_resource_ids_leaves(self):
+
+        for record in self:
+
+            if record._event_in_past():
+                continue
+
+            for resource in record.resource_ids.filtered(
+                    lambda s: s.calendar_id and s.calendar_id.leave_ids):
+
+                conflict_leaves = resource.calendar_id.leave_ids.filtered(
+                    lambda s: s.date_from < record.stop and
+                    s.date_to > record.start
+                )
+
+                if not conflict_leaves:
+                    continue
+
+                datetimes = [(c.date_from, c.date_to) for c in conflict_leaves]
+                raise ValidationError(
+                    _(
+                        "The resource, '%s', is on leave during "
+                        "the following times which are conflicting with "
+                        "this event.\n%s"
+                    )
+                    % (
+                        resource.name,
+                        self._format_datetime_interval_list(datetimes),
+                    )
+                )
+
+    @api.multi
+    @api.constrains('resource_ids', 'start', 'stop')
+    def _check_resource_ids_working_times(self):
+
+        for record in self:
+
+            if record._event_in_past():
+                continue
+
+            event_start = fields.Datetime.from_string(record.start)
+            event_stop = fields.Datetime.from_string(record.stop)
+            event_days = record._get_event_date_list()
+
+            for resource in record.resource_ids.filtered(
+                    lambda s: s.calendar_id):
+
+                available_intervals = []
+                conflict_intervals = []
+
+                for day in event_days:
+
+                    datetime_start = datetime.combine(day, time(00, 00, 00))
+                    datetime_end = datetime.combine(day, time(23, 59, 59))
+
+                    intervals = \
+                        resource.calendar_id.get_working_intervals_of_day(
+                            start_dt=datetime_start,
+                            end_dt=datetime_end,
+                            resource_id=resource.id,
+                        )
+
+                    if not intervals and record.allday:
+                        conflict_intervals.append(
+                            (datetime_start, datetime_end)
+                        )
+                    else:
+                        available_intervals += intervals
+
+                if not record.allday:
+                    conflict_intervals = self.env['resource.calendar'].\
+                        _get_conflicting_unavailable_intervals(
+                            available_intervals, event_start, event_stop
+                        )
+
+                if not conflict_intervals:
+                    continue
+
+                if record.allday:
+                    conflict_intervals = self.env['resource.calendar'].\
+                        _remove_datetime_interval_overlaps(
+                            conflict_intervals
+                        )
+
+                raise ValidationError(
+                    _(
+                        'The resource, %s, is not available during '
+                        'the following dates and times which are '
+                        'conflicting with the event:\n%s'
+                    )
+                    % (
+                        resource.name,
+                        self._format_datetime_interval_list(
+                            conflict_intervals
+                        ),
+                    )
+                )

--- a/calendar_resource/models/calendar_event.py
+++ b/calendar_resource/models/calendar_event.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2013 Savoir-faire Linux
-# Copryight 2017 Laslabs Inc.
+# Copyright 2017 Laslabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from os import linesep
@@ -230,7 +230,7 @@ class CalendarEvent(models.Model):
                             resource_id=resource.id,
                         )
 
-                    if not intervals and record.allday:
+                    if not intervals:
                         conflict_intervals.append(
                             (datetime_start, datetime_end),
                         )
@@ -239,7 +239,7 @@ class CalendarEvent(models.Model):
 
                 ResourceCalendar = self.env['resource.calendar']
 
-                if not record.allday:
+                if available_intervals and not record.allday:
                     conflict_intervals = ResourceCalendar.\
                         _get_conflicting_unavailable_intervals(
                             available_intervals, event_start, event_stop,
@@ -248,11 +248,10 @@ class CalendarEvent(models.Model):
                 if not conflict_intervals:
                     continue
 
-                if record.allday:
-                    conflict_intervals = ResourceCalendar.\
-                        _clean_datetime_intervals(
-                            conflict_intervals,
-                        )
+                conflict_intervals = ResourceCalendar.\
+                    _clean_datetime_intervals(
+                        conflict_intervals,
+                    )
 
                 raise ValidationError(
                     _(

--- a/calendar_resource/models/calendar_event_type.py
+++ b/calendar_resource/models/calendar_event_type.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Laslabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class CalendarEventType(models.Model):
+
+    _inherit = 'calendar.event.type'
+
+    allowed_resource_ids = fields.Many2many(
+        string='Allowed Resources',
+        comodel_name='resource.resource',
+        help='Resources allowed in meetings of this type',
+    )

--- a/calendar_resource/models/resource_calendar.py
+++ b/calendar_resource/models/resource_calendar.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Laslabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from datetime import datetime, time, timedelta
+
+from odoo import api, models
+
+
+class ResourceCalendar(models.Model):
+
+    _inherit = 'resource.calendar'
+
+    @api.model
+    def _get_conflicting_unavailable_intervals(self, intervals,
+                                               start_datetime, end_datetime):
+        """ Finds all unavailable datetime gaps in intervals argument that
+            overlap start_datetime and end_datetime args.
+
+        Args:
+            intervals (list): List of tuples containing the AVAILABLE working
+                datetimes between the start_datetime and end_datetime values.
+                Each tuple contains a start and stop datetime value.
+
+                The working datetime tuples to be supplied to this method can
+                be retrieved like so. Refer to its use in the
+                _check_resource_ids_working_times method in calendar.event in
+                this module.
+
+                    .. code-block:: python
+
+                    intervals = \
+                        resource.calendar_id.get_working_intervals_of_day(
+                            start_dt=datetime_start,
+                            end_dt=datetime_end,
+                            resource_id=resource.id,
+                        )
+
+            start_datetime, end_datetime (datetime): Datetime values
+                of which any unavailable intervals will be checked against
+                for overlaps.
+
+        Returns:
+            list: List containing any intervals of which the start
+            and end datetimes of those intervals overlap the
+            start_datetime and end_datetime args.
+
+        """
+        unavailable_intervals = self._get_unavailable_intervals(
+            intervals=intervals,
+            start_date=start_datetime.date(),
+            end_date=end_datetime.date(),
+        )
+
+        conflicting_intervals = []
+        for interval in unavailable_intervals:
+
+            if all((interval[0] < end_datetime,
+                    interval[1] > start_datetime)):
+                conflicting_intervals.append(interval)
+
+        return conflicting_intervals
+
+    @api.model
+    def _get_unavailable_intervals(self, intervals, start_date, end_date):
+        """ Finds any gaps between intervals, the beginning of start_date,
+            and the end of end_date.
+
+        """
+        start_datetime = datetime.combine(
+            start_date, time(00, 00, 00)
+        )
+        end_datetime = datetime.combine(
+            end_date, time(23, 59, 59)
+        )
+
+        intervals = self._remove_datetime_interval_overlaps(intervals)
+
+        unavailable_intervals = []
+
+        if intervals[0][0] > start_datetime:
+            unavailable_intervals.append(
+                (start_datetime, intervals[0][0])
+            )
+
+        if intervals[-1][1] < end_datetime:
+            unavailable_intervals.append(
+                (intervals[-1][1], end_datetime)
+            )
+
+        if len(intervals) < 2:
+            return unavailable_intervals
+
+        for index, dt_interval in enumerate(intervals):
+
+            if index - 1 < 0:
+                continue
+
+            previous_pair = intervals[index - 1]
+            if previous_pair[1] < dt_interval[0]:
+                unavailable_intervals.append(
+                    (previous_pair[1], dt_interval[0])
+                )
+
+        return self._check_round_up_times_to_next_day(
+            sorted(unavailable_intervals, key=lambda s: s[0])
+        )
+
+    @api.model
+    def _remove_datetime_interval_overlaps(self, intervals):
+
+        intervals = self._check_round_up_times_to_next_day(
+            sorted(intervals, key=lambda s: s[0])
+        )
+
+        remove_index = None
+
+        for index, datetime_range in enumerate(intervals):
+
+            if index - 1 < 0:
+                continue
+
+            prev_range_start = intervals[index - 1][0]
+            prev_range_stop = intervals[index - 1][1]
+
+            range_start = datetime_range[0]
+            range_stop = datetime_range[1]
+
+            if range_stop <= prev_range_stop:
+                remove_index = index
+                break
+
+            conditions = (
+                range_start < prev_range_stop,
+                range_start == prev_range_start,
+            )
+
+            if any(conditions):
+                intervals[index - 1] = (prev_range_start, range_stop)
+                remove_index = index
+                break
+
+        if remove_index is None:
+            return intervals
+
+        del intervals[remove_index]
+        return self._remove_datetime_interval_overlaps(intervals)
+
+    @api.model
+    def _check_round_up_times_to_next_day(self, intervals):
+        for index, datetime_range in enumerate(intervals):
+
+            next_day = datetime_range[1] + timedelta(days=1)
+
+            next_day = next_day.replace(
+                hour=0,
+                minute=0,
+                second=0,
+                microsecond=0,
+            )
+
+            if (next_day - datetime_range[1]).total_seconds() <= 60:
+                intervals[index] = (datetime_range[0], next_day)
+
+        return intervals

--- a/calendar_resource/models/resource_calendar_attendance.py
+++ b/calendar_resource/models/resource_calendar_attendance.py
@@ -18,7 +18,7 @@ class ResourceCalendarAttendance(models.Model):
             if record.date_to < record.date_from:
                 raise ValidationError(_(
                     'End Date cannot be earlier '
-                    'than Starting Date.'
+                    'than Starting Date.',
                 ))
 
     @api.multi
@@ -30,5 +30,5 @@ class ResourceCalendarAttendance(models.Model):
                     'Work to cannot be earlier or the same '
                     'as Work from. If it is a night '
                     'shift, separate the hours into their '
-                    'own working time entries by weekday.'
+                    'own working time entries by weekday.',
                 ))

--- a/calendar_resource/models/resource_calendar_attendance.py
+++ b/calendar_resource/models/resource_calendar_attendance.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2013 Savoir-faire Linux
-# Copryight 2017 Laslabs Inc.
+# Copyright 2017 Laslabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, models
@@ -15,7 +15,11 @@ class ResourceCalendarAttendance(models.Model):
     @api.constrains('date_from', 'date_to')
     def _check_date_from_date_to(self):
         for record in self:
-            if record.date_to < record.date_from:
+            conditions = (
+                record.date_to and record.date_from,
+                record.date_to < record.date_from,
+            )
+            if all(conditions):
                 raise ValidationError(_(
                     'End Date cannot be earlier '
                     'than Starting Date.',

--- a/calendar_resource/models/resource_calendar_attendance.py
+++ b/calendar_resource/models/resource_calendar_attendance.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013 Savoir-faire Linux
+# Copryight 2017 Laslabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class ResourceCalendarAttendance(models.Model):
+
+    _inherit = 'resource.calendar.attendance'
+
+    @api.multi
+    @api.constrains('date_from', 'date_to')
+    def _check_date_from_date_to(self):
+        for record in self:
+            if record.date_to < record.date_from:
+                raise ValidationError(_(
+                    'End Date cannot be earlier '
+                    'than Starting Date.'
+                ))
+
+    @api.multi
+    @api.constrains('hour_from', 'hour_to')
+    def _check_hour_from_hour_to(self):
+        for record in self:
+            if record.hour_to <= record.hour_from:
+                raise ValidationError(_(
+                    'Work to cannot be earlier or the same '
+                    'as Work from. If it is a night '
+                    'shift, separate the hours into their '
+                    'own working time entries by weekday.'
+                ))

--- a/calendar_resource/models/resource_resource.py
+++ b/calendar_resource/models/resource_resource.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Copyright 2013 Savoir-faire Linux
+# Copyright 2017 Laslabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import fields, models
+from odoo import fields, models
 
 
 class ResourceResource(models.Model):
@@ -23,4 +24,9 @@ class ResourceResource(models.Model):
     event_ids = fields.Many2many(
         string='Calendar Events',
         comodel_name='calendar.event',
+    )
+    allowed_event_types = fields.Many2many(
+        string='Event Types',
+        comodel_name='calendar.event.type',
+        help='Event types this resource is allowed at.',
     )

--- a/calendar_resource/security/ir.model.access.csv
+++ b/calendar_resource/security/ir.model.access.csv
@@ -1,0 +1,7 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_resource_resource_manager,resource.resource.manager,resource.model_resource_resource,calendar_resource.group_resource_manager,1,1,1,1
+access_resource_calendar_manager,resource.calendar.manager,resource.model_resource_calendar,calendar_resource.group_resource_manager,1,1,1,1
+access_resource_calendar_attendance_manager,resource.calendar.attendance.manager,resource.model_resource_calendar_attendance,calendar_resource.group_resource_manager,1,1,1,1
+access_resource_calendar_leaves_manager,resource.calendar.leaves.manager,resource.model_resource_calendar_leaves,calendar_resource.group_resource_manager,1,1,1,1
+access_resource_calendar_user,resource.calendar.user,resource.model_resource_calendar,base.group_user,1,0,0,0
+access_resource_calendar_attendance_user,resource.calendar.attendance.user,resource.model_resource_calendar_attendance,base.group_user,1,0,0,0

--- a/calendar_resource/security/resource_security.xml
+++ b/calendar_resource/security/resource_security.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 LasLabs Inc.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record id="ir_module_category_resource" model="ir.module.category">
+        <field name="name">Resources</field>
+        <field name="description">Helps you manage your resources</field>
+        <field name="sequence">100</field>
+    </record>
+
+    <record id="group_resource_manager" model="res.groups">
+        <field name="name">Resource Manager</field>
+        <field name="category_id" ref="ir_module_category_resource" />
+        <field name="users" eval="[(4, ref('base.user_root'))]" />
+    </record>
+
+</odoo>

--- a/calendar_resource/tests/__init__.py
+++ b/calendar_resource/tests/__init__.py
@@ -3,3 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_calendar_event
+from . import test_resource_calendar_attendance
+from . import test_resource_calendar
+from . import test_setup

--- a/calendar_resource/tests/setup.py
+++ b/calendar_resource/tests/setup.py
@@ -45,6 +45,35 @@ class Setup(TransactionCase):
         ]
         self.intervals = self._intervals_to_dt(self.intervals)
 
+        # self.intervals are the same weekdays as the demo
+        # attendances tied to demo data id: resource_calendar_1
+
+        # 2017-03-06: Monday
+        # 2017-03-07: Tuesday
+        # 2017-03-08: Wednesday
+        # 2017-03-09: Thursday
+        # 2017-03-10: Friday
+        # 2017-03-11: Saturday
+        # 2017-03-12: Sunday
+
+        # Overlaps removed and days rounded up
+        self.cleaned_intervals = [
+            ('2017-03-07 00:00:00', '2017-03-08 16:00:00'),
+            ('2017-03-09 09:00:00', '2017-03-10 00:00:00'),
+        ]
+        self.cleaned_intervals = self._intervals_to_dt(
+            self.cleaned_intervals,
+        )
+
+        self.unavailable_intervals = [
+            ('2017-03-06 00:00:00', '2017-03-07 00:00:00'),
+            ('2017-03-08 16:00:00', '2017-03-09 09:00:00'),
+            ('2017-03-10 00:00:00', '2017-03-13 00:00:00'),
+        ]
+        self.unavailable_intervals = self._intervals_to_dt(
+            self.unavailable_intervals,
+        )
+
     def _intervals_to_dt(self, intervals):
         """ Converts all intervals from string values to datetime.
 
@@ -63,14 +92,47 @@ class Setup(TransactionCase):
 
     def _get_datetime_interval(self, start_weekday, start_time,
                                end_weekday, end_time):
-        """ Use this method to ensure events are always in the future """
+        """ Use this method to ensure events are always in the future
+
+        Note that the event start and stop dates will always be the same
+        days of the week as your start_weekday and end_weekday values.
+
+        Args:
+
+            start_weekday (int): Day of the week the event should start.
+
+            start_time (str): Time of day for start_weekday in format:
+                '00:00:00' or '%H:%M:%S'.
+
+            end_weekday (int): Day of the week the event should end on.
+
+            end_time (str): Time of day for end_weekday in format:
+                '00:00:00' or '%H:%M:%S'.
+
+        Example:
+
+            .. code-block python
+
+            start_stop = self._get_datetime_interval(
+                1, '00:00:00',
+                2, '16:00:00',
+            )
+
+        Returns:
+
+            tuple: A tuple with index 0 as the start_datetime, and index
+            1 as the end_datetime.
+
+        """
         start_date = fields.Date.from_string(
             fields.Datetime.now()
         )
+
         # 35 = 5 weeks * 7 days per week
         # done to avoid demo resource leaves
-        # that may be within 7 days of event
+        # that may be in the same month
         start_date += timedelta(days=35)
+
         time_format = '%H:%M:%S'
         start_time = datetime.strptime(start_time, time_format).time()
         end_time = datetime.strptime(end_time, time_format).time()

--- a/calendar_resource/tests/setup.py
+++ b/calendar_resource/tests/setup.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Laslabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from datetime import datetime, timedelta
+
+from odoo import fields
+from odoo.tests.common import TransactionCase
+
+
+MOCK_FORMATS = 'odoo.addons.calendar.models.calendar.Meeting.'\
+               '_get_date_formats'
+
+
+class Setup(TransactionCase):
+
+    def setUp(self):
+        super(Setup, self).setUp()
+        self.resource_1 = self.env.ref('resource.resource_analyst')
+        self.resource_2 = self.env.ref('resource.resource_designer')
+        self.calendar_1 = self.env.ref('calendar_resource.resource_calendar_1')
+
+        self.resource_1.allow_double_book = False
+
+        self.event_type_4 = self.env.ref('calendar.categ_meet4')
+        self.event_type_5 = self.env.ref('calendar.categ_meet5')
+
+        self.leave_1 = self.env.ref(
+            'resource.resource_analyst_leaves_demoleave1'
+        )
+
+        self.env.user.partner_id.tz = 'UTC'
+        self.env.user.lang = 'en_US'
+
+        self.Calendar = self.env['resource.calendar']
+        self.Event = self.env['calendar.event']
+
+        self.intervals = [
+            ('2017-03-07 00:00:00', '2017-03-07 16:00:00'),
+            ('2017-03-07 12:00:00', '2017-03-07 20:00:00'),
+            ('2017-03-07 20:00:00', '2017-03-07 23:59:59'),
+            ('2017-03-08 00:00:00', '2017-03-08 16:00:00'),
+            ('2017-03-08 05:00:00', '2017-03-08 11:30:00'),
+            ('2017-03-09 09:00:00', '2017-03-09 23:59:00'),
+        ]
+        self.intervals = self._intervals_to_dt(self.intervals)
+
+    def _intervals_to_dt(self, intervals):
+        """ Converts all intervals from string values to datetime.
+
+        Args:
+            intervals (list): List of tuples each containing
+                a start and stop string value to be converted
+                to datetime.
+
+        """
+        for index, interval in enumerate(intervals):
+            intervals[index] = (
+                fields.Datetime.from_string(interval[0]),
+                fields.Datetime.from_string(interval[1]),
+            )
+        return intervals
+
+    def _get_datetime_interval(self, start_weekday, start_time,
+                               end_weekday, end_time):
+        """ Use this method to ensure events are always in the future """
+        start_date = fields.Date.from_string(
+            fields.Datetime.now()
+        )
+        # 35 = 5 weeks * 7 days per week
+        # done to avoid demo resource leaves
+        # that may be within 7 days of event
+        start_date += timedelta(days=35)
+        time_format = '%H:%M:%S'
+        start_time = datetime.strptime(start_time, time_format).time()
+        end_time = datetime.strptime(end_time, time_format).time()
+
+        if not start_date.weekday() == 0:
+            while start_date.weekday() != 0:
+                start_date -= timedelta(days=1)
+
+        while start_date.weekday() != start_weekday:
+            start_date += timedelta(days=1)
+
+        end_date = start_date
+        while end_date.weekday() != end_weekday:
+            end_date += timedelta(days=1)
+
+        start_datetime = fields.Datetime.to_string(
+            datetime.combine(start_date, start_time)
+        )
+        end_datetime = fields.Datetime.to_string(
+            datetime.combine(end_date, end_time)
+        )
+
+        return (start_datetime, end_datetime)
+
+    def _create_event(self, vals=None):
+        create_vals = {
+            'name': 'Test Event',
+            'resource_ids': [(6, 0, [self.resource_1.id])],
+            'categ_ids': [(6, 0, [self.event_type_4.id])],
+            'allday': True,
+        }
+        if vals:
+            create_vals.update(vals)
+
+        if 'start' not in create_vals:
+            start_stop = self._get_datetime_interval(
+                1, '12:00:00',
+                3, '14:00:00',
+            )
+            create_vals.update({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+            })
+        return self.env['calendar.event'].create(create_vals)

--- a/calendar_resource/tests/test_calendar_event.py
+++ b/calendar_resource/tests/test_calendar_event.py
@@ -2,36 +2,29 @@
 # Copyright 2017 Laslabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from mock import patch
+
+from odoo import fields
 from odoo.exceptions import ValidationError
 
+from .setup import Setup
+from .setup import MOCK_FORMATS
 
-class TestCalendarEvent(TransactionCase):
 
-    def setUp(self):
-        super(TestCalendarEvent, self).setUp()
-        self.resource_1 = self.env.ref('resource.resource_analyst')
-        self.resource_1.allow_double_book = False
-        self.event_1 = self._create_event()
-
-    def _create_event(self, vals=None):
-        create_vals = {
-            'name': 'Test Event',
-            'start': '2016-05-10 12:00:00',
-            'stop': '2016-05-12 14:00:00',
-            'resource_ids': [(6, 0, [self.resource_1.id])],
-        }
-        if vals:
-            create_vals.update(vals)
-        return self.env['calendar.event'].create(create_vals)
+class TestCalendarEvent(Setup):
 
     def test_overlap_left_outside_date_allow_double_book_true(self):
         """ Test overlap date no raise Validation if allow_double_book True """
         self.resource_1.allow_double_book = True
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            0, '00:00:00',
+            2, '00:00:00',
+        )
         try:
             self._create_event({
-                'start': '2016-05-09 00:00:00',
-                'stop': '2016-05-12 00:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
             self.assertTrue(True)
         except ValidationError:
@@ -43,10 +36,15 @@ class TestCalendarEvent(TransactionCase):
     def test_overlap_left_outside_time_allow_double_book_true(self):
         """ Test overlap time no raise Validation allow_dbl_book True """
         self.resource_1.allow_double_book = True
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            1, '11:00:00',
+            1, '12:30:00',
+        )
         try:
             self._create_event({
-                'start': '2016-05-10 11:00:00',
-                'stop': '2016-05-10 13:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
             self.assertTrue(True)
         except ValidationError:
@@ -57,116 +55,506 @@ class TestCalendarEvent(TransactionCase):
 
     def test_overlap_left_outside_date(self):
         """ Test left side overlap raise ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            0, '00:00:00',
+            2, '00:00:00',
+        )
         with self.assertRaises(ValidationError):
             self._create_event({
-                'start': '2016-05-09 00:00:00',
-                'stop': '2016-05-11 00:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
 
     def test_overlap_right_outside_date(self):
         """ Test right side overlap raise ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            2, '00:00:00',
+            4, '00:00:00',
+        )
         with self.assertRaises(ValidationError):
             self._create_event({
-                'start': '2016-05-11 00:00:00',
-                'stop': '2016-05-13 00:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
 
     def test_match_left_outside_date(self):
         """ Test left side match not ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            0, '00:00:00',
+            1, '12:00:00',
+        )
         try:
             self._create_event({
-                'start': '2016-05-09 00:00:00',
-                'stop': '2016-05-10 12:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
             self.assertTrue(True)
         except ValidationError:
             self.fail(
                 'Should not raise ValidationError '
-                'if stop datetime same as self.event_1 '
+                'if stop datetime same as existing event '
                 'start datetime',
             )
 
     def test_match_right_outside_date(self):
         """ Test date right side match not ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            3, '14:00:00',
+            4, '00:00:00',
+        )
         try:
             self._create_event({
-                'start': '2016-05-12 14:00:00',
-                'stop': '2016-05-13 00:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
             self.assertTrue(True)
         except ValidationError:
             self.fail(
                 'Should not raise ValidationError '
-                'if start datetime same as self.event_1 '
+                'if start datetime same as existing event '
                 'stop datetime',
             )
 
     def test_overlap_both_inside_time(self):
         """ Test time overlap both inside raise ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            2, '00:00:00',
+            2, '10:00:00',
+        )
         with self.assertRaises(ValidationError):
             self._create_event({
-                'start': '2016-05-11 00:00:00',
-                'stop': '2016-05-11 08:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
 
     def test_match_both_inside_date(self):
         """ Test date match both inside raise ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            1, '12:00:00',
+            3, '14:00:00',
+        )
         with self.assertRaises(ValidationError):
             self._create_event({
-                'start': '2016-05-10 12:00:00',
-                'stop': '2016-05-12 14:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
 
     def test_overlap_both_outside_date(self):
         """ Test date overlap both outside raise ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            0, '00:00:00',
+            4, '00:00:00',
+        )
         with self.assertRaises(ValidationError):
             self._create_event({
-                'start': '2016-05-10 12:00:00',
-                'stop': '2016-05-12 14:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
 
     def test_overlap_left_outside_time(self):
         """ Test time left side overlap raise ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            1, '00:00:00',
+            1, '12:30:00',
+        )
         with self.assertRaises(ValidationError):
             self._create_event({
-                'start': '2016-05-10 08:00:00',
-                'stop': '2016-05-11 00:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
 
     def test_overlap_right_outside_time(self):
         """ Test time right side overlap raise ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            3, '13:00:00',
+            3, '15:30:00',
+        )
         with self.assertRaises(ValidationError):
             self._create_event({
-                'start': '2016-05-11 00:00:00',
-                'stop': '2016-05-12 16:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
 
     def test_match_left_outside_time(self):
         """ Test time left side match not ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            1, '00:00:00',
+            1, '12:00:00',
+        )
         try:
             self._create_event({
-                'start': '2016-05-10 10:00:00',
-                'stop': '2016-05-10 12:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
             self.assertTrue(True)
         except ValidationError:
             self.fail(
                 'Should not raise ValidationError '
-                'if stop time same as self.event_1 '
+                'if stop time same as existing event '
                 'start time',
             )
 
     def test_match_right_outside_time(self):
         """ Test time date right side match not ValidationError """
+        self._create_event()
+        start_stop = self._get_datetime_interval(
+            3, '14:00:00',
+            3, '16:00:00',
+        )
         try:
             self._create_event({
-                'start': '2016-05-12 14:00:00',
-                'stop': '2016-05-12 16:00:00',
+                'start': start_stop[0],
+                'stop': start_stop[1],
             })
             self.assertTrue(True)
         except ValidationError:
             self.fail(
                 'Should not raise ValidationError '
-                'if start time same as self.event_1 '
+                'if start time same as existing event '
                 'stop time',
+            )
+
+    def test_check_resource_ids_categ_ids_raise_error(self):
+        """ Test raise ValidationError if resource not allowed """
+        existing_event = self._create_event()
+        with self.assertRaises(ValidationError):
+            existing_event.write({
+                'resource_ids': [(4, [self.resource_2.id])],
+                'categ_ids': [(4, [self.event_type_5.id])],
+            })
+
+    def test_check_resource_ids_categ_ids_no_error(self):
+        """ Test no error if allowed resource added """
+        existing_event = self._create_event()
+        try:
+            existing_event.write({
+                'resource_ids': [(4, [self.resource_2.id])],
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise validation error if '
+                'eligible resource added.'
+            )
+
+    def test_check_resource_ids_categ_ids_no_error_resource(self):
+        """ Test no error if allowed resource added when no categ """
+        existing_event = self._create_event()
+        existing_event.write({
+            'categ_ids': [(5, 0, 0)],
+            'resource_ids': [(5, 0, 0)],
+        })
+        try:
+            existing_event.write({
+                'resource_ids': [(4, [self.resource_2.id])],
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise validation error if '
+                'eligible resource added.'
+            )
+
+    def test_check_resource_ids_categ_ids_no_error_categ(self):
+        """ Test no error if allowed categ added when no resource """
+        existing_event = self._create_event()
+        existing_event.write({
+            'categ_ids': [(5, 0, 0)],
+            'resource_ids': [(5, 0, 0)],
+        })
+        try:
+            existing_event.write({
+                'categ_ids': [(4, [self.event_type_4.id])],
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise validation error if '
+                'eligible categ added.'
+            )
+
+    def test_check_resource_leaves_datetime_in_past(self):
+        """ Test no validationerror if event in the past """
+        self.leave_1.write({
+            'date_from': '2015-04-10 12:00:00',
+            'date_to': '2015-05-12 14:00:00',
+        })
+        try:
+            self._create_event({
+                'start': '2015-04-10 12:00:00',
+                'stop': '2015-05-12 12:00:00'
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise ValidationError if event in past'
+            )
+
+    def test_check_resource_leaves_resource_no_calendar(self):
+        """ Test no validationerror if resource has no calendar_id """
+        self.resource_1.calendar_id = None
+        start_stop = self._get_datetime_interval(
+            0, '12:00:00',
+            6, '20:00:00'
+        )
+        self.leave_1.write({
+            'date_from': start_stop[0],
+            'date_to': start_stop[1],
+        })
+        try:
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise ValidationError if resource '
+                'has no calendar_id'
+            )
+
+    def test_check_resource_leaves(self):
+        """ Test raise ValidationError if conflicting leave """
+        start_stop = self._get_datetime_interval(
+            1, '12:00:00',
+            3, '12:00:00'
+        )
+        self.leave_1.write({
+            'date_from': start_stop[0],
+            'date_to': start_stop[1],
+        })
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+            })
+
+    @patch(MOCK_FORMATS)
+    def test_format_datetime_interval_list(self, datetime_format):
+        """ Test returns correct string """
+        datetime_format.return_value = ('%Y-%m-%d', '%H:%M:%S')
+        intervals = [
+            ('2017-03-07 00:00:00', '2017-03-07 16:00:00'),
+            ('2017-03-07 12:00:00', '2017-03-07 20:00:00'),
+        ]
+        intervals_dt = self._intervals_to_dt([
+            ('2017-03-07 00:00:00', '2017-03-07 16:00:00'),
+            ('2017-03-07 12:00:00', '2017-03-07 20:00:00'),
+        ])
+
+        args = {
+            'start': intervals[0][0],
+            'stop': intervals[0][1],
+            'zallday': False,
+            'zduration': 24,
+        }
+        intervals[0] = self.Event._get_display_time(**args)
+        args.update({
+            'start': intervals[1][0],
+            'stop': intervals[1][1],
+        })
+        intervals[1] = self.Event._get_display_time(**args)
+        exp = '\n%s\n\n%s\n' % (intervals[0], intervals[1])
+
+        res = self.Event._format_datetime_interval_list(intervals_dt)
+        self.assertEquals(
+            exp, res,
+        )
+
+    def test_event_in_past_true(self):
+        """ Test returns true if event in past """
+        event = self._create_event({
+            'start': '2016-06-01 00:00:00',
+            'stop': '2016-06-02 00:00:00',
+        })
+        self.assertTrue(
+            event._event_in_past()
+        )
+
+    def test_event_in_past_false(self):
+        """ Test returns false if event in future """
+        event = self._create_event()
+        self.assertFalse(
+            event._event_in_past()
+        )
+
+    def test_get_event_date_list(self):
+        event = self._create_event({
+            'start': '2016-06-01 00:00:00',
+            'stop': '2016-06-03 00:00:00',
+        })
+        exp = [
+            fields.Date.from_string('2016-06-01'),
+            fields.Date.from_string('2016-06-02'),
+        ]
+        self.assertEquals(
+            exp,
+            event._get_event_date_list()
+        )
+
+    def test_check_resource_ids_working_times_past(self):
+        """ Test no validationerror if event in past """
+        self.resource_1.calendar_id = self.calendar_1
+        try:
+            self._create_event({
+                'start': '2017-03-06 00:00:00',
+                'stop': '2017-03-12 00:00:00',
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not fail if event in past'
+            )
+
+    def test_check_resource_ids_working_times_overlap_left(self):
+        """ Test ValidationError if event overlapping unavailable times """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            0, '23:00:00',
+            2, '20:00:00'
+        )
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+            })
+
+    def test_check_resource_ids_working_times_match_left(self):
+        """ Test no Error if event stop is unavailable time start """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            1, '00:00:00',
+            2, '16:00:00'
+        )
+        try:
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise Error if event stop matches '
+                'unavailable time start'
+            )
+
+    def test_check_resource_ids_working_times_inside_left(self):
+        """ Test no Error if event within working times """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            1, '00:00:00',
+            2, '10:00:00'
+        )
+        try:
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise Error if event witin working times'
+            )
+
+    def test_check_resource_ids_working_times_overlap_right(self):
+        """ Test ValidationError if event overlapping unavailable times """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            3, '00:00:00',
+            5, '20:00:00'
+        )
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+            })
+
+    def test_check_resource_ids_working_times_match_right(self):
+        """ Test no Error if event stop is unavailable time start """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            3, '09:00:00',
+            4, '00:00:00'
+        )
+        try:
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise Error if event stop matches '
+                'unavailable time start'
+            )
+
+    def test_check_resource_ids_working_times_right_whole_day(self):
+        """ Test ValidationError if event on non-working day """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            5, '00:00:00',
+            6, '00:00:00'
+        )
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+            })
+
+    def test_check_resource_ids_working_times_right_whole_day_allday(self):
+        """ Test ValidationError if allday event on non-working day """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            5, '00:00:00',
+            6, '00:00:00'
+        )
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': True,
+            })
+
+    def test_check_resource_ids_working_times_right_week_allday(self):
+        """ Test ValidationError if allday event all week """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            0, '00:00:00',
+            6, '23:59:59'
+        )
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': True,
+            })
+
+    def test_check_resource_ids_working_times_allday_overlap_outside(self):
+        """ Test no Error if allday event is on day with 1+ working time """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            2, '00:00:00',
+            4, '00:00:00'
+        )
+        try:
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': True,
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise Error if event is allday '
+                'and there is at least 1 working interval that day '
             )

--- a/calendar_resource/tests/test_calendar_event.py
+++ b/calendar_resource/tests/test_calendar_event.py
@@ -25,6 +25,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
             self.assertTrue(True)
         except ValidationError:
@@ -45,6 +46,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
             self.assertTrue(True)
         except ValidationError:
@@ -64,6 +66,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
 
     def test_overlap_right_outside_date(self):
@@ -77,6 +80,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
 
     def test_match_left_outside_date(self):
@@ -90,6 +94,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
             self.assertTrue(True)
         except ValidationError:
@@ -110,6 +115,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
             self.assertTrue(True)
         except ValidationError:
@@ -130,6 +136,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
 
     def test_match_both_inside_date(self):
@@ -143,6 +150,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
 
     def test_overlap_both_outside_date(self):
@@ -156,6 +164,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
 
     def test_overlap_left_outside_time(self):
@@ -169,6 +178,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
 
     def test_overlap_right_outside_time(self):
@@ -182,6 +192,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
 
     def test_match_left_outside_time(self):
@@ -195,6 +206,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
             self.assertTrue(True)
         except ValidationError:
@@ -215,6 +227,7 @@ class TestCalendarEvent(Setup):
             self._create_event({
                 'start': start_stop[0],
                 'stop': start_stop[1],
+                'allday': True,
             })
             self.assertTrue(True)
         except ValidationError:
@@ -283,6 +296,23 @@ class TestCalendarEvent(Setup):
                 'eligible categ added.'
             )
 
+    def test_event_in_past_true(self):
+        """ Test returns true if event in past """
+        event = self._create_event({
+            'start': '2016-06-01 00:00:00',
+            'stop': '2016-06-02 00:00:00',
+        })
+        self.assertTrue(
+            event._event_in_past()
+        )
+
+    def test_event_in_past_false(self):
+        """ Test returns false if event in future """
+        event = self._create_event()
+        self.assertFalse(
+            event._event_in_past()
+        )
+
     def test_check_resource_leaves_datetime_in_past(self):
         """ Test no validationerror if event in the past """
         self.leave_1.write({
@@ -292,7 +322,8 @@ class TestCalendarEvent(Setup):
         try:
             self._create_event({
                 'start': '2015-04-10 12:00:00',
-                'stop': '2015-05-12 12:00:00'
+                'stop': '2015-05-12 12:00:00',
+                'allday': True,
             })
             self.assertTrue(True)
         except ValidationError:
@@ -340,7 +371,7 @@ class TestCalendarEvent(Setup):
             })
 
     @patch(MOCK_FORMATS)
-    def test_format_datetime_interval_list(self, datetime_format):
+    def test_format_datetime_intervals_to_str(self, datetime_format):
         """ Test returns correct string """
         datetime_format.return_value = ('%Y-%m-%d', '%H:%M:%S')
         intervals = [
@@ -364,29 +395,177 @@ class TestCalendarEvent(Setup):
             'stop': intervals[1][1],
         })
         intervals[1] = self.Event._get_display_time(**args)
-        exp = '\n%s\n\n%s\n' % (intervals[0], intervals[1])
 
-        res = self.Event._format_datetime_interval_list(intervals_dt)
+        exp = '%s\n\n%s' % (intervals[0], intervals[1])
+        res = self.Event._format_datetime_intervals_to_str(intervals_dt)
+
         self.assertEquals(
             exp, res,
         )
 
-    def test_event_in_past_true(self):
-        """ Test returns true if event in past """
-        event = self._create_event({
-            'start': '2016-06-01 00:00:00',
-            'stop': '2016-06-02 00:00:00',
-        })
-        self.assertTrue(
-            event._event_in_past()
-        )
+    def test_check_resource_ids_working_times_past(self):
+        """ Test no validationerror if event in past """
+        self.resource_1.calendar_id = self.calendar_1
+        try:
+            self._create_event({
+                'start': '2017-03-06 00:00:00',
+                'stop': '2017-03-12 00:00:00',
+                'allday': False,
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not fail if event in past'
+            )
 
-    def test_event_in_past_false(self):
-        """ Test returns false if event in future """
-        event = self._create_event()
-        self.assertFalse(
-            event._event_in_past()
+    def test_check_resource_ids_working_times_overlap_left(self):
+        """ Test ValidationError if event overlapping unavailable times """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            0, '23:00:00',
+            2, '20:00:00',
         )
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': False,
+            })
+
+    def test_check_resource_ids_working_times_match_left(self):
+        """ Test no Error if event stop is unavailable time start """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            1, '00:00:00',
+            2, '16:00:00',
+        )
+        try:
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': False,
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise Error if event stop matches '
+                'unavailable time start'
+            )
+
+    def test_check_resource_ids_working_times_inside_left(self):
+        """ Test no Error if event within working times """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            1, '00:00:00',
+            2, '10:00:00',
+        )
+        try:
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': False,
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise Error if event witin working times'
+            )
+
+    def test_check_resource_ids_working_times_overlap_right(self):
+        """ Test ValidationError if event overlapping unavailable times """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            3, '00:00:00',
+            5, '20:00:00',
+        )
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': False,
+            })
+
+    def test_check_resource_ids_working_times_match_right(self):
+        """ Test no Error if event stop is unavailable time start """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            3, '09:00:00',
+            4, '00:00:00',
+        )
+        try:
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': False,
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise Error if event stop matches '
+                'unavailable time start'
+            )
+
+    def test_check_resource_ids_working_times_right_whole_day(self):
+        """ Test ValidationError if event on non-working day """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            5, '09:00:00',
+            6, '00:00:00',
+        )
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': False,
+            })
+
+    def test_check_resource_ids_working_times_right_whole_day_allday(self):
+        """ Test ValidationError if allday event on non-working day """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            5, '00:00:00',
+            6, '00:00:00',
+        )
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': True,
+            })
+
+    def test_check_resource_ids_working_times_right_week_allday(self):
+        """ Test ValidationError if allday event all week """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            0, '00:00:00',
+            6, '23:59:59',
+        )
+        with self.assertRaises(ValidationError):
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': True,
+            })
+
+    def test_check_resource_ids_working_times_allday_overlap_outside(self):
+        """ Test no Error if allday event is on day with 1+ working time """
+        self.resource_1.calendar_id = self.calendar_1
+        start_stop = self._get_datetime_interval(
+            2, '00:00:00',
+            4, '00:00:00',
+        )
+        try:
+            self._create_event({
+                'start': start_stop[0],
+                'stop': start_stop[1],
+                'allday': True,
+            })
+            self.assertTrue(True)
+        except ValidationError:
+            self.fail(
+                'Should not raise Error if event is allday '
+                'and there is at least 1 working interval that day '
+            )
 
     def test_get_event_date_list(self):
         event = self._create_event({
@@ -401,160 +580,3 @@ class TestCalendarEvent(Setup):
             exp,
             event._get_event_date_list()
         )
-
-    def test_check_resource_ids_working_times_past(self):
-        """ Test no validationerror if event in past """
-        self.resource_1.calendar_id = self.calendar_1
-        try:
-            self._create_event({
-                'start': '2017-03-06 00:00:00',
-                'stop': '2017-03-12 00:00:00',
-            })
-            self.assertTrue(True)
-        except ValidationError:
-            self.fail(
-                'Should not fail if event in past'
-            )
-
-    def test_check_resource_ids_working_times_overlap_left(self):
-        """ Test ValidationError if event overlapping unavailable times """
-        self.resource_1.calendar_id = self.calendar_1
-        start_stop = self._get_datetime_interval(
-            0, '23:00:00',
-            2, '20:00:00'
-        )
-        with self.assertRaises(ValidationError):
-            self._create_event({
-                'start': start_stop[0],
-                'stop': start_stop[1],
-            })
-
-    def test_check_resource_ids_working_times_match_left(self):
-        """ Test no Error if event stop is unavailable time start """
-        self.resource_1.calendar_id = self.calendar_1
-        start_stop = self._get_datetime_interval(
-            1, '00:00:00',
-            2, '16:00:00'
-        )
-        try:
-            self._create_event({
-                'start': start_stop[0],
-                'stop': start_stop[1],
-            })
-            self.assertTrue(True)
-        except ValidationError:
-            self.fail(
-                'Should not raise Error if event stop matches '
-                'unavailable time start'
-            )
-
-    def test_check_resource_ids_working_times_inside_left(self):
-        """ Test no Error if event within working times """
-        self.resource_1.calendar_id = self.calendar_1
-        start_stop = self._get_datetime_interval(
-            1, '00:00:00',
-            2, '10:00:00'
-        )
-        try:
-            self._create_event({
-                'start': start_stop[0],
-                'stop': start_stop[1],
-            })
-            self.assertTrue(True)
-        except ValidationError:
-            self.fail(
-                'Should not raise Error if event witin working times'
-            )
-
-    def test_check_resource_ids_working_times_overlap_right(self):
-        """ Test ValidationError if event overlapping unavailable times """
-        self.resource_1.calendar_id = self.calendar_1
-        start_stop = self._get_datetime_interval(
-            3, '00:00:00',
-            5, '20:00:00'
-        )
-        with self.assertRaises(ValidationError):
-            self._create_event({
-                'start': start_stop[0],
-                'stop': start_stop[1],
-            })
-
-    def test_check_resource_ids_working_times_match_right(self):
-        """ Test no Error if event stop is unavailable time start """
-        self.resource_1.calendar_id = self.calendar_1
-        start_stop = self._get_datetime_interval(
-            3, '09:00:00',
-            4, '00:00:00'
-        )
-        try:
-            self._create_event({
-                'start': start_stop[0],
-                'stop': start_stop[1],
-            })
-            self.assertTrue(True)
-        except ValidationError:
-            self.fail(
-                'Should not raise Error if event stop matches '
-                'unavailable time start'
-            )
-
-    def test_check_resource_ids_working_times_right_whole_day(self):
-        """ Test ValidationError if event on non-working day """
-        self.resource_1.calendar_id = self.calendar_1
-        start_stop = self._get_datetime_interval(
-            5, '00:00:00',
-            6, '00:00:00'
-        )
-        with self.assertRaises(ValidationError):
-            self._create_event({
-                'start': start_stop[0],
-                'stop': start_stop[1],
-            })
-
-    def test_check_resource_ids_working_times_right_whole_day_allday(self):
-        """ Test ValidationError if allday event on non-working day """
-        self.resource_1.calendar_id = self.calendar_1
-        start_stop = self._get_datetime_interval(
-            5, '00:00:00',
-            6, '00:00:00'
-        )
-        with self.assertRaises(ValidationError):
-            self._create_event({
-                'start': start_stop[0],
-                'stop': start_stop[1],
-                'allday': True,
-            })
-
-    def test_check_resource_ids_working_times_right_week_allday(self):
-        """ Test ValidationError if allday event all week """
-        self.resource_1.calendar_id = self.calendar_1
-        start_stop = self._get_datetime_interval(
-            0, '00:00:00',
-            6, '23:59:59'
-        )
-        with self.assertRaises(ValidationError):
-            self._create_event({
-                'start': start_stop[0],
-                'stop': start_stop[1],
-                'allday': True,
-            })
-
-    def test_check_resource_ids_working_times_allday_overlap_outside(self):
-        """ Test no Error if allday event is on day with 1+ working time """
-        self.resource_1.calendar_id = self.calendar_1
-        start_stop = self._get_datetime_interval(
-            2, '00:00:00',
-            4, '00:00:00'
-        )
-        try:
-            self._create_event({
-                'start': start_stop[0],
-                'stop': start_stop[1],
-                'allday': True,
-            })
-            self.assertTrue(True)
-        except ValidationError:
-            self.fail(
-                'Should not raise Error if event is allday '
-                'and there is at least 1 working interval that day '
-            )

--- a/calendar_resource/tests/test_calendar_event.py
+++ b/calendar_resource/tests/test_calendar_event.py
@@ -573,8 +573,8 @@ class TestCalendarEvent(Setup):
             'stop': '2016-06-03 00:00:00',
         })
         exp = [
-            fields.Date.from_string('2016-06-01'),
-            fields.Date.from_string('2016-06-02'),
+            fields.Datetime.from_string('2016-06-01 00:00:00'),
+            fields.Datetime.from_string('2016-06-02 00:00:00'),
         ]
         self.assertEquals(
             exp,

--- a/calendar_resource/tests/test_resource_calendar.py
+++ b/calendar_resource/tests/test_resource_calendar.py
@@ -108,3 +108,13 @@ class TestResourceCalendar(Setup):
                 end,
             )
         )
+
+    def test_clean_datetime_intervals(self):
+        """ Test overlaps correctly removed """
+        res = self.Calendar._clean_datetime_intervals(self.intervals)
+        exp = self.cleaned_intervals
+        self.assertEquals(
+            res,
+            exp,
+            'Intervals are not equal.\nRes:\n%s\nExpect:\n%s' % (res, exp),
+        )

--- a/calendar_resource/tests/test_resource_calendar.py
+++ b/calendar_resource/tests/test_resource_calendar.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Laslabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields
+
+from .setup import Setup
+
+
+class TestResourceCalendar(Setup):
+
+    def test_get_unavailable_intervals_outside_both(self):
+        """ Test returns intervals event outside both """
+        start = fields.Datetime.from_string('2017-03-06 00:00:00')
+        end = fields.Datetime.from_string('2017-03-12 23:59:59')
+        exp = [
+            ('2017-03-06 00:00:00', '2017-03-07 00:00:00'),
+            ('2017-03-08 16:00:00', '2017-03-09 09:00:00'),
+            ('2017-03-10 00:00:00', '2017-03-13 00:00:00'),
+        ]
+        exp = self._intervals_to_dt(exp)
+        self.assertEquals(
+            exp,
+            self.Calendar._get_unavailable_intervals(
+                self.intervals,
+                start.date(),
+                end.date(),
+            )
+        )
+
+    def test_get_conflicting_intervals_inside_both(self):
+        """ Test returns intervals event inside both """
+        start = fields.Datetime.from_string('2017-03-08 17:00:00')
+        end = fields.Datetime.from_string('2017-03-09 08:00:00')
+        exp = [
+            ('2017-03-08 16:00:00', '2017-03-09 09:00:00'),
+        ]
+        exp = self._intervals_to_dt(exp)
+        self.assertEquals(
+            exp,
+            self.Calendar._get_conflicting_unavailable_intervals(
+                self.intervals,
+                start,
+                end,
+            )
+        )
+
+    def test_get_conflicting_intervals_overlap_inside_left(self):
+        """ Test returns intervals event overlap left """
+        start = fields.Datetime.from_string('2017-03-07 10:00:00')
+        end = fields.Datetime.from_string('2017-03-09 06:00:00')
+        exp = [
+            ('2017-03-08 16:00:00', '2017-03-09 09:00:00'),
+        ]
+        exp = self._intervals_to_dt(exp)
+        self.assertEquals(
+            exp,
+            self.Calendar._get_conflicting_unavailable_intervals(
+                self.intervals,
+                start,
+                end,
+            )
+        )
+
+    def test_get_conflicting_intervals_overlap_outside_left(self):
+        """ Test returns intervals event overlap left """
+        start = fields.Datetime.from_string('2017-03-06 10:00:00')
+        end = fields.Datetime.from_string('2017-03-07 06:00:00')
+        exp = [
+            ('2017-03-06 00:00:00', '2017-03-07 00:00:00'),
+        ]
+        exp = self._intervals_to_dt(exp)
+        self.assertEquals(
+            exp,
+            self.Calendar._get_conflicting_unavailable_intervals(
+                self.intervals,
+                start,
+                end,
+            )
+        )
+
+    def test_get_unavailable_intervals_match_right(self):
+        """ Test returns intervals event match right """
+        start = fields.Datetime.from_string('2017-03-09 09:00:00')
+        end = fields.Datetime.from_string('2017-03-10 00:00:00')
+        exp = [
+            ('2017-03-08 16:00:00', '2017-03-09 09:00:00'),
+            ('2017-03-10 00:00:00', '2017-03-11 00:00:00'),
+        ]
+        exp = self._intervals_to_dt(exp)
+        self.assertEquals(
+            exp,
+            self.Calendar._get_unavailable_intervals(
+                self.intervals,
+                start,
+                end,
+            )
+        )
+
+    def test_get_conflicting_intervals_match_right(self):
+        """ Test returns intervals event match right """
+        start = fields.Datetime.from_string('2017-03-09 09:00:00')
+        end = fields.Datetime.from_string('2017-03-10 00:00:00')
+        self.assertFalse(
+            self.Calendar._get_conflicting_unavailable_intervals(
+                self.intervals,
+                start,
+                end,
+            )
+        )

--- a/calendar_resource/tests/test_resource_calendar_attendance.py
+++ b/calendar_resource/tests/test_resource_calendar_attendance.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copryight 2017 Laslabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import ValidationError
+
+
+class TestResourceCalendarAttendance(TransactionCase):
+
+    def setUp(self):
+        super(TestResourceCalendarAttendance, self).setUp()
+        self.attendance_1 = self.env.ref(
+            'resource.calendar_attendance_mon1'
+        )
+
+    def test_check_date_from_date_to(self):
+        """ Test raise ValidationError if dates not in order """
+        with self.assertRaises(ValidationError):
+            self.attendance_1.write({
+                'date_from': fields.Date.from_string('2016-06-06'),
+                'date_to': fields.Date.from_string('2016-05-05'),
+            })
+
+    def test_check_hour_from_hour_to(self):
+        """ Test raise ValidationError if hours not in order """
+        with self.assertRaises(ValidationError):
+            self.attendance_1.write({
+                'hour_from': 5.00,
+                'hour_to': 4.00,
+            })

--- a/calendar_resource/tests/test_resource_calendar_attendance.py
+++ b/calendar_resource/tests/test_resource_calendar_attendance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copryight 2017 Laslabs Inc.
+# Copyright 2017 Laslabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields

--- a/calendar_resource/tests/test_setup.py
+++ b/calendar_resource/tests/test_setup.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Laslabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from mock import patch
+
+from odoo import fields
+
+from .setup import Setup
+
+
+MOCK_DATETIME = 'odoo.addons.calendar_resource.tests.test_calendar_event.'\
+                'fields.Datetime.now'
+
+
+class TestSetup(Setup):
+
+    @patch(MOCK_DATETIME)
+    def test_get_datetime_interval_day_weekday_later(self, mock_datetime):
+        """ Ensure returns future weekday later in week """
+        mock_datetime.return_value = '2017-06-28 12:00:00'
+        res = self._get_datetime_interval(
+            3, '12:00:00',
+            4, '13:00:00',
+        )
+        exp = ('2017-08-03 12:00:00', '2017-08-04 13:00:00')
+        self.assertEquals(
+            res,
+            exp,
+        )
+
+    @patch(MOCK_DATETIME)
+    def test_get_datetime_interval_day_weekday_previous(self, mock_datetime):
+        """ Ensure returns future weekday sooner in week """
+        mock_datetime.return_value = '2016-05-06 12:00:00'
+        res = self._get_datetime_interval(
+            0, '12:00:00',
+            1, '13:00:00',
+        )
+        exp = ('2016-06-06 12:00:00', '2016-06-07 13:00:00')
+        self.assertEquals(
+            res,
+            exp,
+        )
+
+    @patch(MOCK_DATETIME)
+    def test_get_datetime_interval_day_same_weekday(self, mock_datetime):
+        """ Ensure returns future weekday same weekday """
+        mock_datetime.return_value = '2016-05-02 12:00:00'
+        res = self._get_datetime_interval(
+            0, '12:00:00',
+            0, '13:00:00',
+        )
+        exp = ('2016-06-06 12:00:00', '2016-06-06 13:00:00')
+        self.assertEquals(
+            res,
+            exp,
+        )
+
+    def test_intervals_to_dt(self):
+        """ Test changes string to datetime """
+        interval = [('2017-03-07 00:00:00', '2017-03-07 16:00:00')]
+        exp = [(
+            fields.Datetime.from_string(interval[0][0]),
+            fields.Datetime.from_string(interval[0][1]),
+        )]
+        res = self._intervals_to_dt(interval)
+        self.assertEquals(
+            exp, res
+        )

--- a/calendar_resource/views/calendar_menu.xml
+++ b/calendar_resource/views/calendar_menu.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 LasLabs Inc.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <menuitem id="resource.menu_resource_config"
+              name="Resources"
+              parent="calendar.mail_menu_calendar"
+              sequence="30"
+              />
+
+    <menuitem id="resource.menu_resource_calendar"
+              name="Working Times"
+              groups="group_resource_manager"
+              parent="resource.menu_resource_config"
+              action="resource.action_resource_calendar_form"
+              />
+
+    <menuitem id="calendar_menu"
+              name="Calendars"
+              parent="calendar.mail_menu_calendar"
+              sequence="40"
+              />
+
+    <menuitem id="calendar_event_menu"
+              name="Event Calendar"
+              parent="calendar_menu"
+              sequence="42"
+              action="calendar.action_calendar_event"
+              />
+
+</odoo>

--- a/calendar_resource/views/resource_resource_view.xml
+++ b/calendar_resource/views/resource_resource_view.xml
@@ -7,7 +7,7 @@
         <field name="model">resource.resource</field>
         <field name="inherit_id" ref="resource.resource_resource_form" />
         <field name="arch" type="xml">
-            <field name="name" position="replace" />
+            <field name="name" position="replace" priority="10" />
             <xpath expr="//group[group[field[@name='user_id']]]" position="before">
                 <div class="oe_title">
                     <h1>
@@ -22,6 +22,12 @@
             </xpath>
             <xpath expr="//form/group" position="inside">
                 <field name="note" />
+            </xpath>
+            <xpath expr="//field[@name='time_efficiency']" position="after">
+                <field name="allowed_event_types"
+                       widget="many2many_tags"
+                       placeholder="Select Resources"
+                       class="oe_inline" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
### This PR adds the following to calendar_resource:
- [x] Restrict resources to certain calendar event types
- [x] Validate resource leaves on events
- [x] Prevent resources from being added to appointments outside of their availability times

### Looking for Feedback on:

This PR is partially done, however after doing some research into the last 3 tasks, I found that `resource.resource` is highly integrated into its own calendar model, `resource.calendar`. I need to integrate things a bit more with `calendar.event`, but was curious of your thoughts on which path I should take:

1. Create an exclusive calendar view for resources, and have it such that whenever a resource is added to a normal calendar event, the time slot of that event is directly mapped to the exclusive resource calendar.
2. Abandon the exclusive resource calendar view and fully integrate the resource leaves and resource availability times with `calendar.event`.

@lasley @dreispt 
