### PR TITLE
[10.0] fix crm_claim import

### DIFF
--- a/crm_claim/models/crm_claim.py
+++ b/crm_claim/models/crm_claim.py
@@ -6,6 +6,7 @@
 import odoo
 from odoo import _, api, fields, models
 from odoo.tools import html2plaintext
+from odoo.addons.base.res.res_request import referenceable_models
 
 
 class CrmClaim(models.Model):
@@ -62,7 +63,7 @@ class CrmClaim(models.Model):
         detault=fields.Datetime.now,
     )
     model_ref_id = fields.Reference(
-        selection=odoo.addons.base.res.res_request.referenceable_models,
+        selection=referenceable_models,
         string='Reference',
         oldname='ref',
     )

--- a/crm_claim/models/crm_claim.py
+++ b/crm_claim/models/crm_claim.py
@@ -3,7 +3,6 @@
 # Copyright 2017 Vicent Cubells <vicent.cubells@tecnativa.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-import odoo
 from odoo import _, api, fields, models
 from odoo.tools import html2plaintext
 from odoo.addons.base.res.res_request import referenceable_models


### PR DESCRIPTION
The "import" in the line 65 "selection=odoo.addons.base.res.res_request.referenceable_models," broke my environment.

I propose to make the import on the top of the file.