### PR TITLE
crm_deduplicate_acl: Fix the way to add a group to an action

### DIFF
--- a/crm_deduplicate_acl/wizards/partner_merge_view.xml
+++ b/crm_deduplicate_acl/wizards/partner_merge_view.xml
@@ -19,7 +19,7 @@
         </record>
 
         <record id="crm.action_partner_merge" model="ir.actions.act_window">
-            <field name="groups_id">group_manually</field>
+            <field name="groups_id" eval="[(4, ref('crm_deduplicate_acl.group_manually'))]"/>
         </record>
 
 </odoo>


### PR DESCRIPTION
Add correctly the group "crm_deduplicate_acl.group_manually"
to the action "crm.action_partner_merge"

cc @Tecnativa