### PR TITLE
[11.0][FIX] crm_phonecall: fixes to skip duration computation on phonecalls without date

### DIFF
--- a/crm_phonecall/models/crm_phonecall.py
+++ b/crm_phonecall/models/crm_phonecall.py
@@ -125,7 +125,7 @@ class CrmPhonecall(models.Model):
 
     @api.multi
     def compute_duration(self):
-        for phonecall in self:
+        for phonecall in self.filtered('date'):
             if phonecall.duration <= 0:
                 duration = datetime.now() - datetime.strptime(
                     phonecall.date, DEFAULT_SERVER_DATETIME_FORMAT)


### PR DESCRIPTION
`date` field on `crm.phonecall` is not required, so if it is not set on a state change to `done` (eg. convert to opportunity), if duration is recomputed `datetime.strptime()` is called on a `False` value (not set):

https://github.com/OCA/crm/blob/5abedd9753d96ebdd420fe87b30809b065a16cf2/crm_phonecall/models/crm_phonecall.py#L126-L131

Resulting in the following exception:

> 
>  File ".../odoo/api.py", line 680, in call_kw_multi
>     result = method(recs, *args, **kwargs)
>   File ".../crm_phonecall/models/crm_phonecall.py", line 284, in action_button_convert2opportunity
>     opportunity_dict = call.convert_opportunity()
>   File ".../crm_phonecall/models/crm_phonecall.py", line 250, in convert_opportunity
>     call.write(vals)
>   File ".../crm_phonecall/models/crm_phonecall.py", line 120, in write
>     self.compute_duration()
>   File ".../crm_phonecall/models/crm_phonecall.py", line 131, in compute_duration
>     phonecall.date, DEFAULT_SERVER_DATETIME_FORMAT)
> TypeError: strptime() argument 1 must be str, not bool

This change skips `crm.phonecall` records which have no `date` set in `compute_duration()`.