### PR TITLE
[10.0] [FIX] crm_claim: typo date default value

### DIFF
--- a/crm_claim/models/crm_claim.py
+++ b/crm_claim/models/crm_claim.py
@@ -59,7 +59,7 @@ class CrmClaim(models.Model):
     date = fields.Datetime(
         string='Claim Date',
         index=True,
-        detault=fields.Datetime.now,
+        default=fields.Datetime.now,
     )
     model_ref_id = fields.Reference(
         selection=referenceable_models,


### PR DESCRIPTION
 The attribute default of the field date is misspelled.