### PR TITLE
[11.0] [FIX] crm_claim: typo date default value

### DIFF
--- a/crm_claim/models/crm_claim.py
+++ b/crm_claim/models/crm_claim.py
@@ -53,7 +53,7 @@ class CrmClaim(models.Model):
     date = fields.Datetime(
         string='Claim Date',
         index=True,
-        detault=fields.Datetime.now,
+        default=fields.Datetime.now,
     )
     model_ref_id = fields.Reference(
         selection=odoo.addons.base.res.res_request.referenceable_models,


### PR DESCRIPTION
The attribute default of the field date is misspelled.