### PR TITLE
Fix computation of claim count when permissions are changed.

### DIFF
--- a/crm_claim/models/res_partner.py
+++ b/crm_claim/models/res_partner.py
@@ -17,7 +17,7 @@ class ResPartner(models.Model):
     @api.model
     def _compute_claim_count(self):
         partners = self | self.mapped('child_ids')
-        partner_data = self.env['crm.claim'].read_group(
+        partner_data = self.env['crm.claim'].sudo().read_group(
             [('partner_id', 'in', partners.ids)],
             ['partner_id'],
             ['partner_id'],


### PR DESCRIPTION
If users don't have permission to read claims, they would be locked out of opening up the partner form view. This fix enables one to only allow claims to be viewed by e.g. Managers and not regular CRM users.