### PR TITLE
[12.0][FIX] crm_phonecall: make states editable

### DIFF
--- a/crm_phonecall/models/crm_phonecall.py
+++ b/crm_phonecall/models/crm_phonecall.py
@@ -54,7 +54,6 @@ class CrmPhonecall(models.Model):
          ('done', 'Held')
          ],
         string='Status',
-        readonly=True,
         track_visibility='onchange',
         default='open',
         help='The status is set to Confirmed, when a case is created.\n'


### PR DESCRIPTION
There is a status called pending that it will never be used because you can not change the status manually. If you take a look, although the status bar is clickable the field is read-only, so when you click on it, it does nothing.

Any comment will be appreciated.