### PR TITLE
[12.0][FIX] crm_phonecall: when accessing from partner's opportunities active_id is not correct

### DIFF
--- a/crm_phonecall/models/crm_lead.py
+++ b/crm_phonecall/models/crm_lead.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.tools.safe_eval import safe_eval
 
 
 class CrmLead(models.Model):
@@ -26,3 +27,18 @@ class CrmLead(models.Model):
             lead.phonecall_count = self.env[
                 'crm.phonecall'].search_count(
                 [('opportunity_id', '=', lead.id)])
+
+    @api.multi
+    def button_open_phonecall(self):
+        self.ensure_one()
+        action = self.env.ref('crm_phonecall.crm_case_categ_phone_incoming0')
+        action_dict = action.read()[0] if action else {}
+        action_dict['context'] = safe_eval(
+            action_dict.get('context', '{}'))
+        action_dict['context'].update({
+            'default_opportunity_id': self.id,
+            'search_default_opportunity_id': self.id,
+            'default_partner_id': self.partner_id.id,
+            'default_duration': 1.0,
+        })
+        return action_dict

--- a/crm_phonecall/tests/test_crm_phonecall.py
+++ b/crm_phonecall/tests/test_crm_phonecall.py
@@ -126,3 +126,13 @@ class TestCrmPhoneCall(common.SavepointCase):
             'crm_phonecall', 'view_crm_case_phonecalls_filter')
         self.assertEqual(result['search_view_id'], search_view[1])
         self.assertNotEqual(result['res_id'], self.phonecall1.id)
+
+    def test_opportunity_open_phonecall(self):
+        action_dict = self.opportunity2.button_open_phonecall()
+        action_context = action_dict.get('context')
+        self.assertEqual(action_context.get('default_opportunity_id'),
+                         self.opportunity2.id)
+        self.assertEqual(action_context.get('search_default_opportunity_id'),
+                         self.opportunity2.id)
+        self.assertEqual(action_context.get('default_partner_id'),
+                         self.opportunity2.partner_id.id)

--- a/crm_phonecall/views/crm_lead_view.xml
+++ b/crm_phonecall/views/crm_lead_view.xml
@@ -7,10 +7,9 @@
         <field name="inherit_id" ref="crm.crm_case_form_view_leads"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
-                <button class="oe_inline oe_stat_button" type="action"
-                    name="%(crm_phonecall.crm_case_categ_phone_incoming0)d"
-                    icon="fa-phone"
-                    context="{'default_opportunity_id': active_id, 'search_default_opportunity_id': active_id, 'default_partner_id': partner_id, 'default_duration': 1.0}">
+                <button class="oe_inline oe_stat_button" type="object"
+                    name="button_open_phonecall"
+                    icon="fa-phone">
                     <field string="Calls" name="phonecall_count" widget="statinfo"/>
                 </button>
             </xpath>
@@ -22,10 +21,9 @@
         <field name="inherit_id" ref="crm.crm_case_form_view_oppor"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
-                <button class="oe_inline oe_stat_button" type="action"
-                    name="%(crm_phonecall.crm_case_categ_phone_incoming0)d"
-                    icon="fa-phone"
-                    context="{'default_opportunity_id': active_id, 'search_default_opportunity_id': active_id, 'default_partner_id': partner_id, 'default_duration': 1.0}">
+                <button class="oe_inline oe_stat_button" type="object"
+                    name="button_open_phonecall"
+                    icon="fa-phone">
                     <field string="Calls" name="phonecall_count" widget="statinfo"/>
                 </button>
             </xpath>


### PR DESCRIPTION
If you access a partner, and from there access opportunities, when you click into calls of the opportunity, it shows calls related to other opportunity, it takes partner id as opportunity id.