### PR TITLE
[12.0][ADD] crm_won_reason: funcionality to set won reasons

### DIFF
--- a/crm_won_reason/__init__.py
+++ b/crm_won_reason/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/crm_won_reason/__manifest__.py
+++ b/crm_won_reason/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2019 RGB Consulting - Domantas Sidorenkovas
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    'name': "Crm Won Reason",
+    'version': '12.0.1.0.0',
+    'category': 'CRM',
+    'depends': ['crm'],
+    'author': "RGB Consulting,"
+              "Odoo Community Association (OCA)",
+    'license': 'AGPL-3',
+    'website': "https://github.com/OCA/crm",
+    'data': [
+        'security/ir.model.access.csv',
+        'wizard/crm_lead_won_view.xml',
+        'views/crm_lead_view.xml',
+        'views/crm_won_view.xml',
+    ],
+}

--- a/crm_won_reason/__manifest__.py
+++ b/crm_won_reason/__manifest__.py
@@ -7,6 +7,7 @@
     'depends': ['crm'],
     'author': "RGB Consulting,"
               "Odoo Community Association (OCA)",
+    "maintainers": ["admin-rgbconsulting"],
     'license': 'AGPL-3',
     'website': "https://github.com/OCA/crm",
     'data': [

--- a/crm_won_reason/i18n/ca_ES.po
+++ b/crm_won_reason/i18n/ca_ES.po
@@ -1,0 +1,125 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* crm_won_reason
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-09-10 07:38+0000\n"
+"PO-Revision-Date: 2019-09-10 07:38+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__active
+msgid "Active"
+msgstr "Actiu"
+
+#. module: crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_lead_won_view_form
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#. module: crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_won_reason_view_form
+msgid "Channel"
+msgstr "Canal"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__create_uid
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__create_uid
+msgid "Created by"
+msgstr "Creat per"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__create_date
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__create_date
+msgid "Created on"
+msgstr "Creat el"
+
+#. module: crm_won_reason
+#: model_terms:ir.actions.act_window,help:crm_won_reason.crm_won_reason_action
+msgid "Define a new won reason"
+msgstr "Defineixi una nova raó de guany"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__display_name
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__display_name
+msgid "Display Name"
+msgstr "Mostrar Nom"
+
+#. module: crm_won_reason
+#: model:ir.model,name:crm_won_reason.model_crm_lead_won
+msgid "Get Won Reason"
+msgstr "Obtener la razón de ganancia"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__id
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__id
+msgid "ID"
+msgstr "ID"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won____last_update
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason____last_update
+msgid "Last Modified on"
+msgstr "Darrera modificació el"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__write_uid
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__write_uid
+msgid "Last Updated by"
+msgstr "Darrera Actualització per"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__write_date
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__write_date
+msgid "Last Updated on"
+msgstr "Darrera Actualització el"
+
+#. module: crm_won_reason
+#: model:ir.model,name:crm_won_reason.model_crm_lead
+msgid "Lead/Opportunity"
+msgstr "Iniciativa/Oportunitat"
+
+#. module: crm_won_reason
+#: model:ir.actions.server,name:crm_won_reason.action_mark_as_won
+msgid "Mark as won"
+msgstr "Marcar com a bestiar"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__name
+msgid "Name"
+msgstr "Nom"
+
+#. module: crm_won_reason
+#: model:ir.model,name:crm_won_reason.model_crm_won_reason
+msgid "Opp. Won Reason"
+msgstr "Motiu de guany de l'oportunitat"
+
+#. module: crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_lead_won_view_form
+msgid "Submit"
+msgstr "Enviar"
+
+#. module: crm_won_reason
+#: model_terms:ir.actions.act_window,help:crm_won_reason.crm_won_reason_action
+msgid "Use won reasons to explain why an opportunity is won."
+msgstr "Usi motius de guany per a explicar per què s'ha guanyat una oportunitat."
+
+#. module: crm_won_reason
+#: model:ir.actions.act_window,name:crm_won_reason.crm_lead_won_action
+#: model:ir.actions.act_window,name:crm_won_reason.crm_won_reason_action
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead__won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__won_reason_id
+#: model:ir.ui.menu,name:crm_won_reason.menu_crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_lead_won_view_form
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.view_crm_case_opportunities_filter_inherit
+msgid "Won Reason"
+msgstr "Motiu de guany"
+

--- a/crm_won_reason/i18n/crm_won_reason.pot
+++ b/crm_won_reason/i18n/crm_won_reason.pot
@@ -1,0 +1,125 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* crm_won_reason
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-09-10 07:37+0000\n"
+"PO-Revision-Date: 2019-09-10 07:37+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__active
+msgid "Active"
+msgstr ""
+
+#. module: crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_lead_won_view_form
+msgid "Cancel"
+msgstr ""
+
+#. module: crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_won_reason_view_form
+msgid "Channel"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__create_uid
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__create_date
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: crm_won_reason
+#: model_terms:ir.actions.act_window,help:crm_won_reason.crm_won_reason_action
+msgid "Define a new won reason"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__display_name
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model,name:crm_won_reason.model_crm_lead_won
+msgid "Get Won Reason"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__id
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__id
+msgid "ID"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won____last_update
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__write_uid
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__write_date
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model,name:crm_won_reason.model_crm_lead
+msgid "Lead/Opportunity"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.actions.server,name:crm_won_reason.action_mark_as_won
+msgid "Mark as won"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__name
+msgid "Name"
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.model,name:crm_won_reason.model_crm_won_reason
+msgid "Opp. Won Reason"
+msgstr ""
+
+#. module: crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_lead_won_view_form
+msgid "Submit"
+msgstr ""
+
+#. module: crm_won_reason
+#: model_terms:ir.actions.act_window,help:crm_won_reason.crm_won_reason_action
+msgid "Use won reasons to explain why an opportunity is won."
+msgstr ""
+
+#. module: crm_won_reason
+#: model:ir.actions.act_window,name:crm_won_reason.crm_lead_won_action
+#: model:ir.actions.act_window,name:crm_won_reason.crm_won_reason_action
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead__won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__won_reason_id
+#: model:ir.ui.menu,name:crm_won_reason.menu_crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_lead_won_view_form
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.view_crm_case_opportunities_filter_inherit
+msgid "Won Reason"
+msgstr ""
+

--- a/crm_won_reason/i18n/es.po
+++ b/crm_won_reason/i18n/es.po
@@ -1,0 +1,125 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* crm_won_reason
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-09-10 07:38+0000\n"
+"PO-Revision-Date: 2019-09-10 07:38+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__active
+msgid "Active"
+msgstr "Activo"
+
+#. module: crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_lead_won_view_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_won_reason_view_form
+msgid "Channel"
+msgstr "Canal"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__create_uid
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__create_date
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: crm_won_reason
+#: model_terms:ir.actions.act_window,help:crm_won_reason.crm_won_reason_action
+msgid "Define a new won reason"
+msgstr "Defina una nueva razón de ganancia"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__display_name
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__display_name
+msgid "Display Name"
+msgstr "Mostrar Nombre"
+
+#. module: crm_won_reason
+#: model:ir.model,name:crm_won_reason.model_crm_lead_won
+msgid "Get Won Reason"
+msgstr "Obtener la razón de ganancia"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__id
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__id
+msgid "ID"
+msgstr "ID"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won____last_update
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason____last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__write_uid
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__write_uid
+msgid "Last Updated by"
+msgstr "Última actualización de"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__write_date
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: crm_won_reason
+#: model:ir.model,name:crm_won_reason.model_crm_lead
+msgid "Lead/Opportunity"
+msgstr "Iniciativa/Oportunidad"
+
+#. module: crm_won_reason
+#: model:ir.actions.server,name:crm_won_reason.action_mark_as_won
+msgid "Mark as won"
+msgstr "Marcar como ganado"
+
+#. module: crm_won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_won_reason__name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: crm_won_reason
+#: model:ir.model,name:crm_won_reason.model_crm_won_reason
+msgid "Opp. Won Reason"
+msgstr "Motivo de ganancia de la oportunidad"
+
+#. module: crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_lead_won_view_form
+msgid "Submit"
+msgstr "Enviar"
+
+#. module: crm_won_reason
+#: model_terms:ir.actions.act_window,help:crm_won_reason.crm_won_reason_action
+msgid "Use won reasons to explain why an opportunity is won."
+msgstr "Use motivos de ganancia para explicar por qué se ha ganado una oportunidad."
+
+#. module: crm_won_reason
+#: model:ir.actions.act_window,name:crm_won_reason.crm_lead_won_action
+#: model:ir.actions.act_window,name:crm_won_reason.crm_won_reason_action
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead__won_reason
+#: model:ir.model.fields,field_description:crm_won_reason.field_crm_lead_won__won_reason_id
+#: model:ir.ui.menu,name:crm_won_reason.menu_crm_won_reason
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.crm_lead_won_view_form
+#: model_terms:ir.ui.view,arch_db:crm_won_reason.view_crm_case_opportunities_filter_inherit
+msgid "Won Reason"
+msgstr "Motivo de ganancia"
+

--- a/crm_won_reason/models/__init__.py
+++ b/crm_won_reason/models/__init__.py
@@ -1,0 +1,2 @@
+from . import crm_won_reason
+from . import crm_lead

--- a/crm_won_reason/models/crm_lead.py
+++ b/crm_won_reason/models/crm_lead.py
@@ -18,3 +18,9 @@ class Lead(models.Model):
                 'crm_won_reason.crm_lead_won_action').read()[0]
             return action
         return super(Lead, self).action_set_won_rainbowman()
+
+    @api.model
+    def _onchange_stage_id_values(self, stage_id):
+        res = super(Lead, self)._onchange_stage_id_values(stage_id)
+        res['won_reason'] = False
+        return res

--- a/crm_won_reason/models/crm_lead.py
+++ b/crm_won_reason/models/crm_lead.py
@@ -1,0 +1,20 @@
+# Copyright 2019 RGB Consulting - Domantas Sidorenkovas
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class Lead(models.Model):
+    _inherit = "crm.lead"
+
+    won_reason = fields.Many2one('crm.won.reason', string='Won Reason',
+                                 index=True, track_visibility='onchange')
+
+    @api.multi
+    def action_set_won_rainbowman(self):
+        self.ensure_one()
+        if not self.env.context.get('bypass_won_reason', False):
+            action = self.env.ref(
+                'crm_won_reason.crm_lead_won_action').read()[0]
+            return action
+        return super(Lead, self).action_set_won_rainbowman()

--- a/crm_won_reason/models/crm_won_reason.py
+++ b/crm_won_reason/models/crm_won_reason.py
@@ -1,0 +1,12 @@
+# Copyright 2019 RGB Consulting - Domantas Sidorenkovas
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class WonReason(models.Model):
+    _name = "crm.won.reason"
+    _description = 'Opp. Won Reason'
+
+    name = fields.Char('Name', required=True, translate=True)
+    active = fields.Boolean('Active', default=True)

--- a/crm_won_reason/readme/CONFIGURE.rst
+++ b/crm_won_reason/readme/CONFIGURE.rst
@@ -1,0 +1,4 @@
+To configure a **Won Reason** you need to:
+
+#. Go to **CRM > Configuration > Won Reason**
+#. Create a reason to make it selectable for the users

--- a/crm_won_reason/readme/CONTRIBUTORS.rst
+++ b/crm_won_reason/readme/CONTRIBUTORS.rst
@@ -1,0 +1,5 @@
+* `RGB Consulting <https://www.rgbconsulting.com>`_:
+
+  * Domantas Sidorenkovas
+
+Do not contact contributors directly about support or help with technical issues.

--- a/crm_won_reason/readme/DESCRIPTION.rst
+++ b/crm_won_reason/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module adds won reason funcionality to leads (same as lost reason).
+
+A lead can be marked as won through a button or an action. Either way,
+both methods open a wizard that allows specifying the won reason.
+The reason, when set, is shown on the form view of the lead.

--- a/crm_won_reason/readme/ROADMAP.rst
+++ b/crm_won_reason/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+* When you change stages in kanban view or widget in lead form view
+  the wizard is not triggered.

--- a/crm_won_reason/security/ir.model.access.csv
+++ b/crm_won_reason/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_crm_won_reason_manager,crm.won.reason.manager,model_crm_won_reason,sales_team.group_sale_manager,1,1,1,1
+access_crm_won_reason_salesman,crm.won.reason.salesman,model_crm_won_reason,sales_team.group_sale_salesman,1,0,0,0
+access_crm_won_reason_user,crm.won.reason.user,model_crm_won_reason,base.group_user,1,0,0,0

--- a/crm_won_reason/views/crm_lead_view.xml
+++ b/crm_won_reason/views/crm_lead_view.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2019 RGB Consulting - Domantas Sidorenkovas
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="action_mark_as_won" model="ir.actions.server">
+        <field name="name">Mark as won</field>
+        <field name="model_id" ref="model_crm_lead"/>
+        <field name="binding_model_id" ref="crm.model_crm_lead"/>
+        <field name="state">code</field>
+        <field name="code">
+        if record:
+            action_values = env.ref('crm_won_reason.crm_lead_won_action').read()[0]
+            action_values.update({'context': env.context})
+            action = action_values
+        </field>
+    </record>
+
+    <record id="crm_case_form_view_oppor_inherit" model="ir.ui.view">
+        <field name="name">crm.lead.form.opportunity.inherit</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.crm_case_form_view_oppor"/>
+        <field name="arch" type="xml">
+            <field name="lost_reason" position="after">
+                <field name="won_reason"
+                       attrs="{'invisible': [('probability', '!=', 100)]}"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_crm_case_opportunities_filter_inherit" model="ir.ui.view">
+        <field name="name">crm.lead.search.opportunity.inherit</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.view_crm_case_opportunities_filter"/>
+        <field name="arch" type="xml">
+            <field name="lost_reason" position="after">
+                <field name="won_reason"/>
+            </field>
+            <filter name="lostreason" position="after">
+                <filter string="Won Reason" name="won_reason"
+                        context="{'group_by':'won_reason'}"/>
+            </filter>
+        </field>
+    </record>
+</odoo>

--- a/crm_won_reason/views/crm_won_view.xml
+++ b/crm_won_reason/views/crm_won_view.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2019 RGB Consulting - Domantas Sidorenkovas
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="crm_won_reason_view_form" model="ir.ui.view">
+        <field name="name">crm.won.reason.form</field>
+        <field name="model">crm.won.reason</field>
+        <field name="arch" type="xml">
+            <form string="Channel">
+                <group>
+                    <field name="name"/>
+                    <field name="active"/>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="crm_won_reason_action" model="ir.actions.act_window">
+        <field name="name">Won Reason</field>
+        <field name="res_model">crm.won.reason</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Define a new won reason
+            </p>
+            <p>
+                Use won reasons to explain why an opportunity is won.
+            </p>
+        </field>
+    </record>
+
+    <menuitem
+            id="menu_crm_won_reason"
+            action="crm_won_reason_action"
+            parent="crm.menu_crm_config_lead"
+            sequence="7"/>
+</odoo>

--- a/crm_won_reason/wizard/__init__.py
+++ b/crm_won_reason/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import crm_lead_won

--- a/crm_won_reason/wizard/crm_lead_won.py
+++ b/crm_won_reason/wizard/crm_lead_won.py
@@ -1,0 +1,18 @@
+# Copyright 2019 RGB Consulting - Domantas Sidorenkovas
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class CrmLeadWon(models.TransientModel):
+    _name = 'crm.lead.won'
+    _description = 'Get Won Reason'
+
+    won_reason_id = fields.Many2one('crm.won.reason', 'Won Reason')
+
+    @api.multi
+    def action_won_reason_apply(self):
+        leads = self.env['crm.lead'].browse(self.env.context.get('active_ids'))
+        leads.write({'won_reason': self.won_reason_id.id})
+        return leads.with_context(
+            bypass_won_reason=True).action_set_won_rainbowman()

--- a/crm_won_reason/wizard/crm_lead_won_view.xml
+++ b/crm_won_reason/wizard/crm_lead_won_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2019 RGB Consulting - Domantas Sidorenkovas
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="crm_lead_won_view_form" model="ir.ui.view">
+        <field name="name">crm.lead.won.form</field>
+        <field name="model">crm.lead.won</field>
+        <field name="arch" type="xml">
+            <form string="Won Reason">
+                <group class="oe_title">
+                    <field name="won_reason_id"/>
+                </group>
+                <footer>
+                    <button name="action_won_reason_apply" string="Submit"
+                            type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary"
+                            special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="crm_lead_won_action" model="ir.actions.act_window">
+        <field name="name">Won Reason</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">crm.lead.won</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="crm_lead_won_view_form"/>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module adds won reason funcionality to leads (same as lost reason).

A lead can be marked as won through a button or an action. Either way,
both methods open a wizard that allows specifying the won reason.
The reason, when set, is shown on the form view of the lead.
