### PR TITLE
[12.0] FIX crm_lead_vat tests

### DIFF
--- a/crm_lead_vat/tests/test_lead.py
+++ b/crm_lead_vat/tests/test_lead.py
@@ -17,7 +17,9 @@ class LeadCase(TransactionCase):
     def test_transfered_values(self):
         """Field gets transfered when creating partner."""
         self.lead.vat = self.test_field
-        self.lead.handle_partner_assignation()
+        partner_ids = self.lead.handle_partner_assignation()
+        for lead_id in partner_ids:
+            self.env["crm.lead"].browse(lead_id).partner_id = partner_ids[lead_id]
         self.assertEqual(self.lead.partner_id.vat, self.test_field)
 
     def test_onchange_partner_id(self):


### PR DESCRIPTION
after https://github.com/odoo/odoo/commit/e1833936255839cd34eba5758ca4c3124fd2522c

Spotted at https://github.com/OCA/l10n-italy/pull/1529 (`l10n_it_fiscalcode_crm` uses the same test as `crm_lead_vat`)