### PR TITLE
date_deadline field Issue

### DIFF
--- a/crm_lead_product/report/crm_product_report.py
+++ b/crm_lead_product/report/crm_product_report.py
@@ -21,7 +21,7 @@ class ActivityReport(models.Model):
     create_date = fields.Datetime('Create Date', readonly=True)
     date_closed = fields.Datetime('Closed Date', readonly=True)
     date_conversion = fields.Datetime('Conversion Date', readonly=True)
-    date_deadline = fields.Datetime('Deadline Date', readonly=True)
+    date_deadline = fields.Date('Deadline Date', readonly=True)
     date_open = fields.Datetime('Open Date', readonly=True)
     lost_reason = fields.Many2one('crm.lost.reason', 'Lost Reason',
                                   readonly=True)


### PR DESCRIPTION
where i face this isssue is ...
when i open CRM -----------> Reporting --------------> Pipeline by product
report open -------------> then i go to Tree View/View List and open any form as oper open form i face this issue ....
raise TypeError("%s (field %s) must be string or datetime, not date." % (value, self))
TypeError: 2019-09-20 (field crm.product.report.date_deadline) must be string or datetime, not date.
so what i do is ...

date_deadline = fields.Datetime('Deadline Date', readonly=True)
to
date_deadline = fields.Date('Deadline Date', readonly=True)

why i change
bcz
date_deadline field come from crm.lead model in crm.lead its Date filed not Datetime field...
so i change this code as per above mention. after that report run smoothly .....

if i my action is correct i want to contribute this small effort ?