### PR TITLE
[12.0] remove unicodecsv from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ env:
 
 
 install:
-  - pip install unicodecsv
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - git clone --depth=1 https://github.com/OCA/partner-contact.git ${HOME}/partner-contact
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}


### PR DESCRIPTION
I find no import of unicodecsv in the addons of this repo.