### PR TITLE
[12.0][FIX] crm_meeting_commercial_partner: fix context for schedule_meeting action

### DIFF
--- a/crm_meeting_commercial_partner/models/res_partner.py
+++ b/crm_meeting_commercial_partner/models/res_partner.py
@@ -28,5 +28,4 @@ class ResPartner(models.Model):
         self.ensure_one()
         action = super(ResPartner, self).schedule_meeting()
         action['domain'] = [('partner_ids', 'child_of', self.ids)]
-        action['context'].pop('search_default_partner_ids')
         return action


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Remove dropped search_default_partner_ids context for schedule_meeting action

**Current behavior before PR:**

- Can't open **Meeting Stats Button** from partner form view with installed  crm_meeting_commercial_partner addon
- Related code change in Odoo CRM Addon [here](https://github.com/odoo/odoo/commit/dac91bc18db73fbf0e7f9452f96a28676b49fdbe#diff-adf85ad8e2a0fb7d37ef5367d58fdf37)
- Screenshot from OCA Runbot Instance 
![Bildschirmfoto_2020-04-23_21-23-41](https://user-images.githubusercontent.com/226753/80140796-c9829680-85a8-11ea-8144-09e67f679b4f.png)



```python
Traceback (most recent call last):
  File "/.repo_requirements/odoo/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/.repo_requirements/odoo/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/.repo_requirements/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/.repo_requirements/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/.repo_requirements/odoo/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/service/model.py", line 98, in wrapper
    return f(dbname, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/OCB-12.0/addons/web/controllers/main.py", line 966, in call_button
    action = self._call_kw(model, method, args, {})
  File "/home/odoo/OCB-12.0/addons/web/controllers/main.py", line 954, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 759, in call_kw
    return _call_kw_multi(method, model, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 746, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/build/OCA/crm/crm_meeting_commercial_partner/models/res_partner.py", line 31, in schedule_meeting
    action['context'].pop('search_default_partner_ids')
KeyError: 'search_default_partner_ids'
```


**Desired behavior after PR is merged:**

- Open **Meeting Stats Button** from partner form view with installed  crm_meeting_commercial_partner addon without errors

