### PR TITLE
[11.0][FIX] crm_meeting_commercial_partner: fix context for schedule_meeting action

### DIFF
--- a/crm_meeting_commercial_partner/models/res_partner.py
+++ b/crm_meeting_commercial_partner/models/res_partner.py
@@ -28,5 +28,4 @@ class ResPartner(models.Model):
         self.ensure_one()
         action = super(ResPartner, self).schedule_meeting()
         action['domain'] = [('partner_ids', 'child_of', self.ids)]
-        action['context'].pop('search_default_partner_ids')
         return action


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Remove dropped search_default_partner_ids context for schedule_meeting action

**Current behavior before PR:**

- Can't open **Meeting Stats Button** from partner form view with installed  crm_meeting_commercial_partner addon
- Related code change in Odoo CRM Addon [here](https://github.com/odoo/odoo/commit/957e7eb77ed18e4a1c14ef4ef55bd54503c56f44)
- Screenshot from OCA Runbot Instance 
![Odoo11_Screen_2020-04-23_22-01-01](https://user-images.githubusercontent.com/226753/80144040-1a48be00-85ae-11ea-9f83-9bb1482efd1c.png)




```python
Traceback (most recent call last):
  File "/.repo_requirements/odoo/odoo/http.py", line 653, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/.repo_requirements/odoo/odoo/http.py", line 312, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/.repo_requirements/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/.repo_requirements/odoo/odoo/http.py", line 695, in dispatch
    result = self._call_function(**self.params)
  File "/.repo_requirements/odoo/odoo/http.py", line 344, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/service/model.py", line 97, in wrapper
    return f(dbname, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/http.py", line 337, in checked_call
    result = self.endpoint(*a, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 939, in __call__
    return self.method(*args, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 517, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/OCB-11.0/addons/web/controllers/main.py", line 938, in call_button
    action = self._call_kw(model, method, args, {})
  File "/home/odoo/OCB-11.0/addons/web/controllers/main.py", line 926, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 699, in call_kw
    return call_kw_multi(method, model, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 690, in call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/build/OCA/crm/crm_meeting_commercial_partner/models/res_partner.py", line 31, in schedule_meeting
    action['context'].pop('search_default_partner_ids')
KeyError: 'search_default_partner_ids
```


**Desired behavior after PR is merged:**

- Open **Meeting Stats Button** from partner form view with installed  crm_meeting_commercial_partner addon without errors

