### PR TITLE
[12.0][IMP] crm_phonecall: Add field direction in calls and improve views

### DIFF
--- a/crm_phonecall/README.rst
+++ b/crm_phonecall/README.rst
@@ -37,14 +37,14 @@ Usage
 
 To use this module, you need to:
 
-#. Go to *Sales > Phone Calls > Logged Calls > Create*.
+#. Go to *CRM > Phone Calls > Logged Calls > Create*.
 #. If your user has *Show Scheduled Calls Menu* permission, you will see
    scheduled calls menu too.
 #. In any moment you can schedule another call, schedule a meeting or convert
    call contact to opportunity.
-#. Calls can be categorized and you can manage categories in *Sales >
-   Configuration > Leads & Opportunities > Phone Calls > Categories*.
-#. Calls can be analyzed in *Sales > Reports > Phone Calls Analysis*.
+#. Calls can be categorized and you can manage categories in *CRM >
+   Configuration > Pipeline > Phone Calls > Categories*.
+#. Calls can be analyzed in *CRM > Reporting > Phone Calls Analysis*.
 
 Known issues / Roadmap
 ======================
@@ -76,11 +76,17 @@ Contributors
 * Odoo S.A.
 * `Tecnativa <https://www.tecnativa.com>`_
 
-  * Vicent Cubells <vicent.cubells@tecnativa.com>
-  * Jairo Llopis <jairo.llopis@tecnativa.com>
-  * David Vidal <david.vidal@tecnativa.com>
+  * Vicent Cubells
+  * Jairo Llopis
+  * David Vidal
+  * Alexandre Díaz
 
 * Anand Kansagra <kansagraanand@hotmail.com>
+
+* `Druidoo <https://www.druidoo.io>`_
+
+  * Iván Todorovich <ivan.todorovich@druidoo.io>
+  * Manuel Marquez <manuel.marquez@druidoo.io>
 
 Maintainers
 ~~~~~~~~~~~

--- a/crm_phonecall/__manifest__.py
+++ b/crm_phonecall/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "Odoo S.A., "
               "Tecnativa, "
               "Odoo Community Association (OCA)",
-    "website": "https://www.tecnativa.com",
+    "website": "https://github.com/OCA/crm",
     "license": "AGPL-3",
     "depends": [
         'crm',
@@ -21,6 +21,7 @@
         'views/crm_phonecall_view.xml',
         'views/res_partner_view.xml',
         'views/crm_lead_view.xml',
+        'views/res_config_settings_views.xml',
         'report/crm_phonecall_report_view.xml',
     ],
     'installable': True,

--- a/crm_phonecall/models/__init__.py
+++ b/crm_phonecall/models/__init__.py
@@ -2,3 +2,4 @@ from . import crm_phonecall
 from . import calendar
 from . import res_partner
 from . import crm_lead
+from . import res_config_settings

--- a/crm_phonecall/models/res_config_settings.py
+++ b/crm_phonecall/models/res_config_settings.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    group_show_form_view = fields.Boolean(
+        'Enable form view for phone calls',
+        help='By default form is disabled for calls, with this group it is enabled.',
+        implied_group='crm_phonecall.group_show_form_view',
+        default=True,
+    )

--- a/crm_phonecall/readme/CONTRIBUTORS.rst
+++ b/crm_phonecall/readme/CONTRIBUTORS.rst
@@ -1,8 +1,14 @@
 * Odoo S.A.
 * `Tecnativa <https://www.tecnativa.com>`_
 
-  * Vicent Cubells <vicent.cubells@tecnativa.com>
-  * Jairo Llopis <jairo.llopis@tecnativa.com>
-  * David Vidal <david.vidal@tecnativa.com>
+  * Vicent Cubells
+  * Jairo Llopis
+  * David Vidal
+  * Alexandre Díaz
 
 * Anand Kansagra <kansagraanand@hotmail.com>
+
+* `Druidoo <https://www.druidoo.io>`_
+
+  * Iván Todorovich <ivan.todorovich@druidoo.io>
+  * Manuel Marquez <manuel.marquez@druidoo.io>

--- a/crm_phonecall/readme/USAGE.rst
+++ b/crm_phonecall/readme/USAGE.rst
@@ -1,10 +1,10 @@
 To use this module, you need to:
 
-#. Go to *Sales > Phone Calls > Logged Calls > Create*.
+#. Go to *CRM > Phone Calls > Logged Calls > Create*.
 #. If your user has *Show Scheduled Calls Menu* permission, you will see
    scheduled calls menu too.
 #. In any moment you can schedule another call, schedule a meeting or convert
    call contact to opportunity.
-#. Calls can be categorized and you can manage categories in *Sales >
-   Configuration > Leads & Opportunities > Phone Calls > Categories*.
-#. Calls can be analyzed in *Sales > Reports > Phone Calls Analysis*.
+#. Calls can be categorized and you can manage categories in *CRM >
+   Configuration > Pipeline > Phone Calls > Categories*.
+#. Calls can be analyzed in *CRM > Reporting > Phone Calls Analysis*.

--- a/crm_phonecall/security/crm_security.xml
+++ b/crm_phonecall/security/crm_security.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="group_scheduled_calls" model="res.groups">
         <field name="name">Show Scheduled Calls Menu</field>
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
-
+    <record id="group_show_form_view" model="res.groups">
+        <field name="name">Enable form view for phone calls</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
 </odoo>

--- a/crm_phonecall/static/description/index.html
+++ b/crm_phonecall/static/description/index.html
@@ -387,14 +387,14 @@ ul.auto-toc {
 <h1><a class="toc-backref" href="#id1">Usage</a></h1>
 <p>To use this module, you need to:</p>
 <ol class="arabic simple">
-<li>Go to <em>Sales &gt; Phone Calls &gt; Logged Calls &gt; Create</em>.</li>
+<li>Go to <em>CRM &gt; Phone Calls &gt; Logged Calls &gt; Create</em>.</li>
 <li>If your user has <em>Show Scheduled Calls Menu</em> permission, you will see
 scheduled calls menu too.</li>
 <li>In any moment you can schedule another call, schedule a meeting or convert
 call contact to opportunity.</li>
-<li>Calls can be categorized and you can manage categories in <em>Sales &gt;
-Configuration &gt; Leads &amp; Opportunities &gt; Phone Calls &gt; Categories</em>.</li>
-<li>Calls can be analyzed in <em>Sales &gt; Reports &gt; Phone Calls Analysis</em>.</li>
+<li>Calls can be categorized and you can manage categories in <em>CRM &gt;
+Configuration &gt; Pipeline &gt; Phone Calls &gt; Categories</em>.</li>
+<li>Calls can be analyzed in <em>CRM &gt; Reporting &gt; Phone Calls Analysis</em>.</li>
 </ol>
 </div>
 <div class="section" id="known-issues-roadmap">
@@ -425,12 +425,18 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li>Odoo S.A.</li>
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a><ul>
-<li>Vicent Cubells &lt;<a class="reference external" href="mailto:vicent.cubells&#64;tecnativa.com">vicent.cubells&#64;tecnativa.com</a>&gt;</li>
-<li>Jairo Llopis &lt;<a class="reference external" href="mailto:jairo.llopis&#64;tecnativa.com">jairo.llopis&#64;tecnativa.com</a>&gt;</li>
-<li>David Vidal &lt;<a class="reference external" href="mailto:david.vidal&#64;tecnativa.com">david.vidal&#64;tecnativa.com</a>&gt;</li>
+<li>Vicent Cubells</li>
+<li>Jairo Llopis</li>
+<li>David Vidal</li>
+<li>Alexandre Díaz</li>
 </ul>
 </li>
 <li>Anand Kansagra &lt;<a class="reference external" href="mailto:kansagraanand&#64;hotmail.com">kansagraanand&#64;hotmail.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.druidoo.io">Druidoo</a><ul>
+<li>Iván Todorovich &lt;<a class="reference external" href="mailto:ivan.todorovich&#64;druidoo.io">ivan.todorovich&#64;druidoo.io</a>&gt;</li>
+<li>Manuel Marquez &lt;<a class="reference external" href="mailto:manuel.marquez&#64;druidoo.io">manuel.marquez&#64;druidoo.io</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/crm_phonecall/tests/test_crm_phonecall.py
+++ b/crm_phonecall/tests/test_crm_phonecall.py
@@ -27,11 +27,13 @@ class TestCrmPhoneCall(common.SavepointCase):
             'phone': '123 456 789',
             'mobile': '123 456 789',
             'type': 'contact',
+            'email': "partner1@crm_phonecall"
         })
         cls.partner2 = partner_obj.create({
             'name': 'Partner2',
             'phone': '789 654 321',
             'mobile': '789 654 321',
+            'email': "partner2@crm_phonecall"
         })
         cls.phonecall1 = cls.env['crm.phonecall'].create({
             'name': 'Call #1 for test',
@@ -54,6 +56,9 @@ class TestCrmPhoneCall(common.SavepointCase):
         })
         cls.tag = cls.env.ref('crm.categ_oppor1')
 
+    def test_partner_phonecall_count(self):
+        self.assertEqual(self.partner1.phonecall_count, 1)
+
     def test_on_change_partner(self):
         """Partner change method test."""
         self.phonecall1.partner_id = self.partner2
@@ -66,6 +71,14 @@ class TestCrmPhoneCall(common.SavepointCase):
         self.assertTrue(self.phonecall1.date_closed)
         self.phonecall1.state = 'open'
         self.assertEqual(self.phonecall1.duration, 0.0)
+
+    def test_compute_duration(self):
+        call_without_date = self.env['crm.phonecall'].create({
+            'name': 'Call without date',
+            'duration': 120,
+        })
+        call_without_date.compute_duration()
+        self.assertEqual(call_without_date.duration, 0)
 
     def test_schedule_another_phonecall(self):
         """Schedule another phonecall."""

--- a/crm_phonecall/views/crm_phonecall_view.xml
+++ b/crm_phonecall/views/crm_phonecall_view.xml
@@ -27,7 +27,9 @@
         <field name="name">CRM - Phone Calls Tree</field>
         <field name="model">crm.phonecall</field>
         <field name="arch" type="xml">
-            <tree colors="gray:state in ('cancel','done');blue:state in ('pending',)" string="Phone Calls">
+            <tree decoration-muted="state in ('cancel','done')"
+                  decoration-info="state in ('pending',)"
+                  string="Phone Calls">
                 <field name="date"/>
                 <field name="name"/>
                 <field name="partner_id"/>
@@ -85,25 +87,52 @@
                         </div>
                         <h2><field name="partner_phone"/></h2>
                     </div>
-                    <group col="4">
-                        <field name="date"/>
-                        <field name="user_id" context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'sales_team.group_sale_salesman_all_leads']}"/>
-                        <label for="duration"/>
-                        <div>
-                            <field name="duration" widget="float_time" class="oe_inline" style="vertical-align:baseline"/> <b> min(s)</b>
-                        </div>
-                        <field name="team_id" colspan="1" widget="selection"
-                               groups="sales_team.group_sale_salesman"/>
-                        <field name="partner_id"/>
-                        <field name="tag_ids" widget="many2many_tags"/>
-                        <field name="partner_mobile"/>
-                        <field name="priority" widget="priority"/>
-                        <field name="opportunity_id" context="{'opportunity_id': opportunity_id}"/>
-                    </group>
-                    <group string="Tracking" groups="base.group_no_one" name="categorization">
-                        <field name="campaign_id"/>
-                        <field name="source_id"/>
-                        <field name="medium_id"/>
+                    <group>
+                        <group>
+                            <field name="date"/>
+                            <label for="duration"/>
+                            <div>
+                                <field
+                                    name="duration"
+                                    widget="float_time"
+                                    class="oe_inline"
+                                    style="vertical-align:baseline"
+                              />
+                                <b> min(s)</b>
+                            </div>
+                            <field name="partner_id"/>
+                            <field name="partner_mobile"/>
+                            <field
+                                name="opportunity_id"
+                                context="{'opportunity_id': opportunity_id}"
+                           />
+                        </group>
+                        <group>
+                            <field
+                                name="user_id"
+                                context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'sales_team.group_sale_salesman_all_leads']}"
+                           />
+                            <field
+                                name="team_id"
+                                colspan="1"
+                                widget="selection"
+                                groups="sales_team.group_sale_salesman"
+                           />
+                            <field name="tag_ids" widget="many2many_tags"/>
+                            <field name="priority" widget="priority"/>
+                        </group>
+                        <group
+                            string="Tracking"
+                            groups="base.group_no_one"
+                            name="categorization"
+                        >
+                            <field name="campaign_id"/>
+                            <field name="source_id"/>
+                            <field name="medium_id"/>
+                        </group>
+                        <group name="additional_info" string="Additional Info">
+                            <field name="direction" widget="radio"/>
+                        </group>
                     </group>
                     <field name="description" placeholder="Description..."/>
                 </sheet>
@@ -127,7 +156,8 @@
                 <field name="partner_mobile" invisible="1"/>
                 <field name="user_id" context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'sales_team.group_sale_salesman']}"/>
                 <field name="tag_ids" widget="many2many_tags" invisible="1"/>
-                <field name="state" invisible="1"/>
+                <field name="direction"/>
+                <field name="state"/>
                 <field name="create_date" invisible="1"/>
                 <field name="opportunity_id" invisible="1"/>
                 <field name="campaign_id" groups="base.group_no_one"/>
@@ -145,6 +175,18 @@
                         states="open,pending"
                         icon="fa-hand-pointer-o"
                         type="object" attrs="{'invisible':[('opportunity_id','!=',False)]}"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="crm_case_inbound_phone_tree_view_no_editable" model="ir.ui.view">
+        <field name="name">CRM - Logged Phone Calls - Tree No Editable</field>
+        <field name="model">crm.phonecall</field>
+        <field name="inherit_id" ref="crm_phonecall.crm_case_inbound_phone_tree_view"/>
+        <field name="groups_id" eval="[(4,ref('crm_phonecall.group_show_form_view'))]"/>
+        <field name="arch" type="xml">
+            <tree position="attributes">
+                <attribute name="editable"/>
             </tree>
         </field>
     </record>
@@ -183,14 +225,16 @@
                 <field name="opportunity_id"/>
                 <field name="team_id" string="Sales Team" groups="sales_team.group_sale_manager"/>
                 <group expand="0" string="Group By">
-                    <filter string="Partner" name="partner"
+                    <filter string="Partner" name="groupby_partner"
                             context="{'group_by':'partner_id'}"/>
-                    <filter string="Responsible" name="responsible"
+                    <filter string="Responsible" name="groupby_responsible"
                             context="{'group_by':'user_id'}"/>
-                    <filter string="Creation" name="creation"
+                    <filter string="Creation" name="groupby_creation"
                             help="Creation Date" context="{'group_by':'create_date'}"/>
-                    <filter string="Month" name="month"
+                    <filter string="Month" name="groupby_month"
                             context="{'group_by':'date'}" help="Calls Date by Month"/>
+                    <filter string="State" name="groupby_state"
+                            context="{'group_by':'state'}" help="Calls by status"/>
                 </group>
             </search>
         </field>

--- a/crm_phonecall/views/res_config_settings_views.xml
+++ b/crm_phonecall/views/res_config_settings_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.crm.phonecalls</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="crm.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div data-string="CRM" position="inside">
+                <h2>Phonecalls</h2>
+                <div class="row mt16 o_settings_container">
+                    <div class="col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="group_show_form_view" />
+                        </div>
+                        <div
+                            class="o_setting_right_pane"
+                            id="crm_phonecall_show_form_settings"
+                        >
+                            <label
+                                string="Enable form view for phone calls"
+                                for="group_show_form_view"
+                            />
+                            <div class="text-muted">
+                                By default form view is disabled for calls, with this setting it is enabled for all users.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Taking up from pr #322

Added:
- Changed website in manifest
- test for crm.phonecall compute_duration method
- test for res.partner _compute_phonecall_count
- improve code coverage for test_convert2opportunity (set email for partner)
- Backport crm_phonecall view changes that has been made in crm_phonecall V13 (replaced color by decoration-* in tree view)
- Backport code changes made in crm_phonecall V13

Original pr:
Author: Manuel Alejandro
@mamcode: Think we should have this also in V12, thank you for that work


**Form view in 12.0**

![crm_phonecall_in_out_v12](https://user-images.githubusercontent.com/226753/81473182-11d2c300-91fd-11ea-967d-9d06d56383fb.png)

**CRM settings in 12.0**

![crm_phonecall_in_out_v12_settings](https://user-images.githubusercontent.com/226753/81473409-88bc8b80-91fe-11ea-8402-c3260800eb90.png)



