### PR TITLE
[12.0][FIX] Remove unnecessary utf8 coding comments and replace http license links

### DIFF
--- a/crm_claim/__init__.py
+++ b/crm_claim/__init__.py
@@ -1,4 +1,4 @@
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import models
 from . import report

--- a/crm_claim/__manifest__.py
+++ b/crm_claim/__manifest__.py
@@ -1,7 +1,7 @@
 # Copyright 2015-2017 Odoo S.A.
 # Copyright 2017 Tecnativa - Vicent Cubells
 # Copyright 2018 Tecnativa - Cristina Martin R.
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 {
     'name': 'Claims Management',

--- a/crm_claim/models/__init__.py
+++ b/crm_claim/models/__init__.py
@@ -1,4 +1,4 @@
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import crm_claim
 from . import crm_claim_category

--- a/crm_claim/models/crm_claim.py
+++ b/crm_claim/models/crm_claim.py
@@ -1,6 +1,6 @@
 # Copyright 2015-2017 Odoo S.A.
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import _, api, fields, models
 from odoo.tools import html2plaintext

--- a/crm_claim/models/crm_claim_category.py
+++ b/crm_claim/models/crm_claim_category.py
@@ -1,6 +1,6 @@
 # Copyright 2015-2017 Odoo S.A.
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import fields, models
 

--- a/crm_claim/models/crm_claim_stage.py
+++ b/crm_claim/models/crm_claim_stage.py
@@ -1,6 +1,6 @@
 # Copyright 2015-2017 Odoo S.A.
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import fields, models
 

--- a/crm_claim/models/res_partner.py
+++ b/crm_claim/models/res_partner.py
@@ -1,6 +1,6 @@
 # Copyright 2015-2017 Odoo S.A.
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import api, fields, models
 

--- a/crm_claim/report/__init__.py
+++ b/crm_claim/report/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Odoo S.A.
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import crm_claim_report

--- a/crm_claim/report/crm_claim_report.py
+++ b/crm_claim/report/crm_claim_report.py
@@ -1,7 +1,7 @@
 # Copyright 2015-2017 Odoo S.A.
 # Copyright 2017 Tecnativa - Vicent Cubells
 # Copyright 2018 Tecnativa - Cristina Martin R.
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from psycopg2.extensions import AsIs
 from odoo import api, fields, models, tools

--- a/crm_claim/tests/__init__.py
+++ b/crm_claim/tests/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import test_crm_claim

--- a/crm_claim/tests/test_crm_claim.py
+++ b/crm_claim/tests/test_crm_claim.py
@@ -1,5 +1,5 @@
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests import common
 

--- a/crm_claim_code/__init__.py
+++ b/crm_claim_code/__init__.py
@@ -1,4 +1,4 @@
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import models
 from .hooks import create_code_equal_to_id, assign_old_sequences

--- a/crm_claim_code/__manifest__.py
+++ b/crm_claim_code/__manifest__.py
@@ -1,7 +1,7 @@
 # Copyright 2015-2018 Tecnativa - Pedro M. Baeza
 # Copyright 2015 AvanzOsc (http://www.avanzosc.es)
 # Copyright 2017 Tecnativa - Vicent Cubells <vicent.cubells@tecnativa.com>
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 {
     "name": "Sequential Code for Claims",

--- a/crm_claim_code/hooks.py
+++ b/crm_claim_code/hooks.py
@@ -1,4 +1,4 @@
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo.api import Environment
 from odoo import SUPERUSER_ID

--- a/crm_claim_code/models/__init__.py
+++ b/crm_claim_code/models/__init__.py
@@ -1,3 +1,3 @@
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import crm_claim

--- a/crm_claim_code/models/crm_claim.py
+++ b/crm_claim_code/models/crm_claim.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Tecnativa - Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2015 AvanzOsc (http://www.avanzosc.es)
 # Copyright 2017 Tecnativa - Vicent Cubells <vicent.cubells@tecnativa.com>
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import api, fields, models
 

--- a/crm_claim_code/tests/__init__.py
+++ b/crm_claim_code/tests/__init__.py
@@ -1,3 +1,3 @@
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import test_crm_claim_code

--- a/crm_claim_code/tests/test_crm_claim_code.py
+++ b/crm_claim_code/tests/test_crm_claim_code.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Tecnativa - Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2015 AvanzOsc (http://www.avanzosc.es)
 # Copyright 2017 Tecnativa - Vicent Cubells <vicent.cubells@tecnativa.com>
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo.tests import common
 

--- a/crm_claim_type/__manifest__.py
+++ b/crm_claim_type/__manifest__.py
@@ -1,6 +1,6 @@
 # Copyright 2015 Vauxoo: Yanina Aular <yani@vauxoo.com>,
-#                        Osval Reyes <osval@vauxoo.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2015 Vauxoo: Osval Reyes <osval@vauxoo.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'CRM Claim Types',

--- a/crm_claim_type/models/crm_claim.py
+++ b/crm_claim_type/models/crm_claim.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Vauxoo: Yanina Aular <yani@vauxoo.com>,
 #                        Osval Reyes <osval@vauxoo.com>
 # Copyright 2017 Bhavesh Odedra <bodedra@ursainfosystems.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
 

--- a/crm_claim_type/models/crm_claim_stage.py
+++ b/crm_claim_type/models/crm_claim_stage.py
@@ -2,7 +2,7 @@
 # Copyright 2015 Vauxoo
 # Copyright 2013 Camptocamp
 # Copyright 2009-2013 Akretion
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
 

--- a/crm_claim_type/models/crm_claim_type.py
+++ b/crm_claim_type/models/crm_claim_type.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Vauxoo: Yanina Aular <yani@vauxoo.com>,
 #                        Osval Reyes <osval@vauxoo.com>
 # Copyright 2017 Bhavesh Odedra <bodedra@ursainfosystems.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
 

--- a/crm_industry/__init__.py
+++ b/crm_industry/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/crm_industry/__manifest__.py
+++ b/crm_industry/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright 2015 Antiun Ingenieria S.L. - Javier Iniesta
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "CRM Industry",

--- a/crm_industry/models/__init__.py
+++ b/crm_industry/models/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import crm_lead

--- a/crm_industry/models/crm_lead.py
+++ b/crm_industry/models/crm_lead.py
@@ -1,6 +1,6 @@
 # Copyright 2015 Antiun Ingenieria S.L. - Javier Iniesta
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo import _, api, exceptions, fields, models
 
 

--- a/crm_industry/tests/__init__.py
+++ b/crm_industry/tests/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import test_crm_lead

--- a/crm_industry/tests/test_crm_lead.py
+++ b/crm_industry/tests/test_crm_lead.py
@@ -1,6 +1,6 @@
 # Copyright 2015 Antiun Ingenieria S.L. - Javier Iniesta
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests.common import TransactionCase
 from odoo.exceptions import ValidationError

--- a/crm_industry/views/crm_lead_view.xml
+++ b/crm_industry/views/crm_lead_view.xml
@@ -2,7 +2,7 @@
 <!-- Copyright 2015 Antiun Ingenieria S.L. - Javier Iniesta
      Copyright 2018 Eficent Business and IT Consulting Services, S.L.
      Copyright 2019 Tecnativa - Alexandre Díaz <alexandre.diaz@tecnativa.com>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
 <odoo>
 
 <record model="ir.ui.view" id="crm_case_form_view_leads">

--- a/crm_lead_code/__init__.py
+++ b/crm_lead_code/__init__.py
@@ -1,6 +1,4 @@
-##############################################################################
-# For copyright and license notices, see __manifest__.py file in root directory
-##############################################################################
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import models
 from odoo import api, SUPERUSER_ID

--- a/crm_lead_code/__manifest__.py
+++ b/crm_lead_code/__manifest__.py
@@ -1,23 +1,6 @@
-##############################################################################
-#
-# Copyright (c)
-#    2015 Serv. Tec. Avanzados - Pedro M. Baeza (http://www.serviciosbaeza.com)
-#    2015 AvanzOsc (http://www.avanzosc.es)
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Serv. Tec. Avanzados - Pedro M. Baeza (http://www.serviciosbaeza.com)
+# Copyright 2015 AvanzOsc (http://www.avanzosc.es)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 {
     "name": "Sequential Code for Leads / Opportunities",

--- a/crm_lead_code/models/__init__.py
+++ b/crm_lead_code/models/__init__.py
@@ -1,4 +1,3 @@
-#############################################################################
-# For copyright and license notices, see __manifest__.py file in root directory
-##############################################################################
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
 from . import crm_lead

--- a/crm_lead_code/models/crm_lead.py
+++ b/crm_lead_code/models/crm_lead.py
@@ -1,6 +1,4 @@
-##############################################################################
-# For copyright and license notices, see __manifest__.py file in root directory
-##############################################################################
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import api, fields, models, _
 

--- a/crm_lead_code/tests/__init__.py
+++ b/crm_lead_code/tests/__init__.py
@@ -1,5 +1,3 @@
-##############################################################################
-# For copyright and license notices, see __manifest__.py file in root directory
-##############################################################################
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import test_crm_lead_code

--- a/crm_lead_code/tests/test_crm_lead_code.py
+++ b/crm_lead_code/tests/test_crm_lead_code.py
@@ -1,6 +1,4 @@
-##############################################################################
-# For copyright and license notices, see __manifest__.py file in root directory
-##############################################################################
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo.tests.common import TransactionCase
 

--- a/crm_lead_firstname/__init__.py
+++ b/crm_lead_firstname/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/crm_lead_firstname/__manifest__.py
+++ b/crm_lead_firstname/__manifest__.py
@@ -1,5 +1,5 @@
-# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Firstname and Lastname in Leads",
     "summary": "Specify split names for contacts in leads",

--- a/crm_lead_firstname/models/__init__.py
+++ b/crm_lead_firstname/models/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import crm_lead

--- a/crm_lead_firstname/models/crm_lead.py
+++ b/crm_lead_firstname/models/crm_lead.py
@@ -1,5 +1,5 @@
-# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
 

--- a/crm_lead_firstname/tests/__init__.py
+++ b/crm_lead_firstname/tests/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import test_crm_lead

--- a/crm_lead_firstname/tests/test_crm_lead.py
+++ b/crm_lead_firstname/tests/test_crm_lead.py
@@ -1,5 +1,5 @@
-# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests.common import SavepointCase
 

--- a/crm_lead_firstname/views/crm_lead_view.xml
+++ b/crm_lead_firstname/views/crm_lead_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- © 2016 Antiun Ingeniería S.L. - Jairo Llopis
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<!-- Copyright 2016 Antiun Ingeniería S.L. - Jairo Llopis
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
 
 <odoo>
     <record id="crm_case_form_view_leads" model="ir.ui.view">

--- a/crm_lead_product/__init__.py
+++ b/crm_lead_product/__init__.py
@@ -1,4 +1,4 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models
 from . import report

--- a/crm_lead_product/__manifest__.py
+++ b/crm_lead_product/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2017 Eficent Business and IT Consulting Services S.L.
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 {
     'name': 'Lead Line Product',

--- a/crm_lead_product/models/__init__.py
+++ b/crm_lead_product/models/__init__.py
@@ -1,4 +1,4 @@
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import crm_lead_line
 from . import crm_lead

--- a/crm_lead_product/models/crm_lead.py
+++ b/crm_lead_product/models/crm_lead.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018 Eficent Business and IT Consulting Services S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
 

--- a/crm_lead_product/models/crm_lead_line.py
+++ b/crm_lead_product/models/crm_lead_line.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018 Eficent Business and IT Consulting Services S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
 

--- a/crm_lead_product/report/__init__.py
+++ b/crm_lead_product/report/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import crm_product_report

--- a/crm_lead_product/report/crm_product_report.py
+++ b/crm_lead_product/report/crm_product_report.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2017 Eficent Business and IT Consulting Services S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from psycopg2.extensions import AsIs
 

--- a/crm_lead_product/tests/__init__.py
+++ b/crm_lead_product/tests/__init__.py
@@ -1,3 +1,3 @@
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from  . import test_crm_lead_line

--- a/crm_lead_product/tests/test_crm_lead_line.py
+++ b/crm_lead_product/tests/test_crm_lead_line.py
@@ -1,4 +1,4 @@
-# © 2017-TODAY Eficent Business and IT Consulting Services S.L.
+# Copyright 2017-2020 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
 from odoo.tests import common

--- a/crm_lead_vat/__init__.py
+++ b/crm_lead_vat/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2015 Antiun Ingeniería, S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/crm_lead_vat/__manifest__.py
+++ b/crm_lead_vat/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright 2015 Antiun Ingeniería, S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "VAT in leads",
     "summary": "Add VAT field to leads",

--- a/crm_lead_vat/models/crm_lead.py
+++ b/crm_lead_vat/models/crm_lead.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015 Antiun Ingeniería, S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
 

--- a/crm_lead_vat/tests/__init__.py
+++ b/crm_lead_vat/tests/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2015 Antiun Ingeniería, S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import test_lead

--- a/crm_lead_vat/tests/test_lead.py
+++ b/crm_lead_vat/tests/test_lead.py
@@ -1,5 +1,5 @@
 # Copyright 2015 Antiun Ingeniería, S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests.common import TransactionCase
 

--- a/crm_location/__init__.py
+++ b/crm_location/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/crm_location/__manifest__.py
+++ b/crm_location/__manifest__.py
@@ -1,6 +1,6 @@
 # Copyright 2015 Antiun Ingenieria - Endika Iglesias <endikaig@antiun.com>
 # Copyright 2017 Tecnativa - Luis Martínez
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
 
 {
     'name': 'CRM location',

--- a/crm_location/models/__init__.py
+++ b/crm_location/models/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
 
 from . import crm_lead

--- a/crm_location/models/crm_lead.py
+++ b/crm_location/models/crm_lead.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Antiun Ingenieria - Endika Iglesias <endikaig@antiun.com>
 # Copyright 2017 Tecnativa - Luis Martínez
 # Copyright 2019 Tecnativa - Alexandre Díaz
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import api, fields, models
 

--- a/crm_location/tests/__init__.py
+++ b/crm_location/tests/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0
 
 from . import test_crm_location

--- a/crm_location/tests/test_crm_location.py
+++ b/crm_location/tests/test_crm_location.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Tecnativa - Luis M. Ontalba
 # Copyright 2019 Tecnativa - Alexandre Díaz
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0
 
 from odoo.tests import common
 

--- a/crm_location_nuts/__init__.py
+++ b/crm_location_nuts/__init__.py
@@ -1,3 +1,3 @@
-# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/crm_location_nuts/__manifest__.py
+++ b/crm_location_nuts/__manifest__.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # Copyright 2017 David Vidal <david.vidal@tecnativa.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'NUTS Regions in CRM',

--- a/crm_location_nuts/models/__init__.py
+++ b/crm_location_nuts/models/__init__.py
@@ -1,3 +1,3 @@
-# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import crm_lead

--- a/crm_location_nuts/models/crm_lead.py
+++ b/crm_location_nuts/models/crm_lead.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # Copyright 2017 David Vidal <david.vidal@tecnativa.com>
 # Copyright 2019 Alexandre Díaz <alexandre.diaz@tecnativa.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
 

--- a/crm_location_nuts/tests/__init__.py
+++ b/crm_location_nuts/tests/__init__.py
@@ -1,3 +1,3 @@
-# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import test_crm_location_nuts

--- a/crm_location_nuts/tests/test_crm_location_nuts.py
+++ b/crm_location_nuts/tests/test_crm_location_nuts.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - David Vidal
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
 
 from odoo.addons.base_location_nuts.tests.test_base_location_nuts\
     import TestBaseLocationNuts

--- a/crm_phonecall/__manifest__.py
+++ b/crm_phonecall/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "CRM Phone Calls",

--- a/crm_phonecall/models/calendar.py
+++ b/crm_phonecall/models/calendar.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2016 Odoo SA (<http://www.odoo.com>)
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
 

--- a/crm_phonecall/models/crm_lead.py
+++ b/crm_phonecall/models/crm_lead.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2016 Odoo SA (<http://www.odoo.com>)
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
 from odoo.tools.safe_eval import safe_eval

--- a/crm_phonecall/models/crm_phonecall.py
+++ b/crm_phonecall/models/crm_phonecall.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2016 Odoo SA (<http://www.odoo.com>)
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from functools import reduce
 

--- a/crm_phonecall/models/res_partner.py
+++ b/crm_phonecall/models/res_partner.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2016 Odoo SA (<http://www.odoo.com>)
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
 

--- a/crm_phonecall/report/crm_phonecall_report.py
+++ b/crm_phonecall/report/crm_phonecall_report.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2010 Tiny SPRL (<http://tiny.be>)
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from psycopg2.extensions import AsIs
 
 from odoo import tools

--- a/crm_phonecall/tests/test_crm_phonecall.py
+++ b/crm_phonecall/tests/test_crm_phonecall.py
@@ -1,5 +1,5 @@
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests import common
 

--- a/crm_phonecall/wizard/crm_phonecall_to_phonecall.py
+++ b/crm_phonecall/wizard/crm_phonecall_to_phonecall.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2010 Tiny SPRL (<http://tiny.be>)
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import time
 

--- a/crm_phonecall_planner/__init__.py
+++ b/crm_phonecall_planner/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import wizards

--- a/crm_phonecall_planner/__manifest__.py
+++ b/crm_phonecall_planner/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright 2017 Jairo Llopis <jairo.llopis@tecnativa.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Phonecall planner",
     "summary": "Schedule phone calls according to some criteria",

--- a/crm_phonecall_planner/tests/__init__.py
+++ b/crm_phonecall_planner/tests/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import test_planner

--- a/crm_phonecall_planner/tests/test_planner.py
+++ b/crm_phonecall_planner/tests/test_planner.py
@@ -1,5 +1,5 @@
 # Copyright 2017 Jairo Llopis <jairo.llopis@tecnativa.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from __future__ import division
 from datetime import datetime, timedelta

--- a/crm_phonecall_planner/wizards/__init__.py
+++ b/crm_phonecall_planner/wizards/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import crm_phonecall_planner

--- a/crm_phonecall_planner/wizards/crm_phonecall_planner.py
+++ b/crm_phonecall_planner/wizards/crm_phonecall_planner.py
@@ -1,5 +1,5 @@
 # Copyright 2017 Jairo Llopis <jairo.llopis@tecnativa.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from __future__ import division
 from datetime import datetime, timedelta

--- a/crm_phonecall_planner/wizards/crm_phonecall_planner_view.xml
+++ b/crm_phonecall_planner/wizards/crm_phonecall_planner_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2017 Jairo Llopis <jairo.llopis@tecnativa.com>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 
 <odoo>
 

--- a/crm_phonecall_summary_predefined/__init__.py
+++ b/crm_phonecall_summary_predefined/__init__.py
@@ -1,4 +1,4 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models
 from .hooks import convert_names_to_many2one

--- a/crm_phonecall_summary_predefined/__manifest__.py
+++ b/crm_phonecall_summary_predefined/__manifest__.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Antiun Ingeniería S.L. - Jairo Llopis
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Restricted Summary for Phone Calls",
     "summary": "Allows to choose from a defined summary list",

--- a/crm_phonecall_summary_predefined/hooks.py
+++ b/crm_phonecall_summary_predefined/hooks.py
@@ -1,5 +1,5 @@
 # Copyright 2017 Vicent Cubells <vicent.cubells@tecnativa.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from psycopg2 import IntegrityError
 

--- a/crm_phonecall_summary_predefined/models/__init__.py
+++ b/crm_phonecall_summary_predefined/models/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import crm_phonecall

--- a/crm_phonecall_summary_predefined/models/crm_phonecall.py
+++ b/crm_phonecall_summary_predefined/models/crm_phonecall.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Antiun Ingeniería S.L. - Jairo Llopis
 # Copyright 2017 Tecnativa - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
 

--- a/crm_phonecall_summary_predefined/views/crm_phonecall_summary_view.xml
+++ b/crm_phonecall_summary_predefined/views/crm_phonecall_summary_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2016 Antiun Ingeniería S.L. - Jairo Llopis
      Copyright 2017 Tecnativa - Vicent Cubells
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
 
 <odoo>
 

--- a/crm_phonecall_summary_predefined/views/crm_phonecall_view.xml
+++ b/crm_phonecall_summary_predefined/views/crm_phonecall_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2016 Antiun Ingeniería S.L. - Jairo Llopis
      Copyright 2017 Tecnativa - Vicent Cubells
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
 
 <odoo>
 

--- a/crm_sale_marketing/__manifest__.py
+++ b/crm_sale_marketing/__manifest__.py
@@ -1,6 +1,6 @@
-# © 2015 Eficent Business and IT Consulting Services S.L.
+# Copyright 2015 Eficent Business and IT Consulting Services S.L.
 # - Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# Copyright 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {

--- a/crm_stage_type/__init__.py
+++ b/crm_stage_type/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/crm_stage_type/__manifest__.py
+++ b/crm_stage_type/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "CRM Stage Type",

--- a/crm_stage_type/models/__init__.py
+++ b/crm_stage_type/models/__init__.py
@@ -1,4 +1,4 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import crm_lead
 from . import crm_stage

--- a/crm_stage_type/models/crm_stage.py
+++ b/crm_stage_type/models/crm_stage.py
@@ -1,5 +1,5 @@
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
 

--- a/crm_stage_type/tests/__init__.py
+++ b/crm_stage_type/tests/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import test_crm_stage_type

--- a/crm_stage_type/tests/test_crm_stage_type.py
+++ b/crm_stage_type/tests/test_crm_stage_type.py
@@ -1,5 +1,5 @@
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests.common import TransactionCase
 

--- a/crm_stage_type/views/crm_lead_views.xml
+++ b/crm_stage_type/views/crm_lead_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- Copyright 2018 Eficent Business and IT Consulting Services, S.L.
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
 <odoo>
 
     <record id="crm_case_form_view_leads" model="ir.ui.view">

--- a/crm_stage_type/views/crm_stage_views.xml
+++ b/crm_stage_type/views/crm_stage_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2018 Eficent Business and IT Consulting Services, S.L.
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
 <odoo>
 
     <record id="crm_lead_stage_search" model="ir.ui.view">

--- a/marketing_crm_partner/__init__.py
+++ b/marketing_crm_partner/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/marketing_crm_partner/__manifest__.py
+++ b/marketing_crm_partner/__manifest__.py
@@ -2,7 +2,7 @@
 # Copyright 2016 Tecnativa S.L. - Vicent Cubells
 # Copyright 2017 Tecnativa S.L. - David Vidal
 # Copyright 2018 Tecnativa S.L. - Cristina Martin R.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Tracking Fields in Partners",
     "summary": "Copy tracking fields from leads to partners",

--- a/marketing_crm_partner/models/__init__.py
+++ b/marketing_crm_partner/models/__init__.py
@@ -1,4 +1,4 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import crm_lead
 from . import res_partner

--- a/marketing_crm_partner/models/crm_lead.py
+++ b/marketing_crm_partner/models/crm_lead.py
@@ -2,7 +2,7 @@
 # Copyright 2016 Tecnativa S.L. - Vicent Cubells
 # Copyright 2016 Tecnativa S.L. - David Vidal
 # Copyright 2018 Tecnativa S.L. - Cristina Martin R.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, models
 

--- a/marketing_crm_partner/models/res_partner.py
+++ b/marketing_crm_partner/models/res_partner.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Tecnativa S.L. - Jairo Llopis
 # Copyright 2016 Tecnativa S.L. - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import models
 

--- a/marketing_crm_partner/tests/__init__.py
+++ b/marketing_crm_partner/tests/__init__.py
@@ -1,3 +1,3 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import test_lead

--- a/marketing_crm_partner/tests/test_lead.py
+++ b/marketing_crm_partner/tests/test_lead.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Tecnativa S.L. - Jairo Llopis
 # Copyright 2016 Tecnativa S.L. - Vicent Cubells
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests.common import TransactionCase
 

--- a/marketing_crm_partner/views/res_partner_view.xml
+++ b/marketing_crm_partner/views/res_partner_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- © 2016 Tecnativa S.L. - Jairo Llopis
-     © 2016 Tecnativa S.L. - Vicent Cubells
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<!-- Copyright 2016 Tecnativa S.L. - Jairo Llopis
+     Copyright 2016 Tecnativa S.L. - Vicent Cubells
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
 
 <odoo>
 


### PR DESCRIPTION
**Remove linting error `C8202(unnecessary-utf8-coding-comment)` for 12.0 pipeline**


![utf8_comments](https://user-images.githubusercontent.com/226753/81699459-ad676c00-9467-11ea-9305-73bb3dd3aa7a.png)

**Replace old http license links with https**