### PR TITLE
[12.0][FIX] crm_phonecall: fix constraint error

### DIFF
--- a/crm_phonecall/wizard/crm_phonecall_to_phonecall.py
+++ b/crm_phonecall/wizard/crm_phonecall_to_phonecall.py
@@ -28,7 +28,7 @@ class CrmPhonecall2phonecall(models.TransientModel):
     phone = fields.Char()
     tag_ids = fields.Many2many(
         comodel_name='crm.lead.tag',
-        relation='crm_phonecall_tag_rel',
+        relation='crm_phonecall2phonecall_tag_rel',
         column1='phone_id',
         column2='tag_id',
         string='Tags',


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Rename relation name for tag_ids in `crm.phonecall2phonecall` to avoid constraint error on system without demo data.

- [ ] Check migration script possibilities 

**Current behavior before PR:**

- Can't schedule another call without constraint errors

**Desired behavior after PR is merged:**

- Schedule another call without constraint errors

**Steps to reproduce:**

1. Install crm_phonecall addon without demo data/on new system (id sequence = 1 for first new record needed)
2. Create first call with at least one tag
3. Schedule another call on previous created record
4. Don't change the preselected tags in wizard form
5. Click Schedule Call
6. Error

![crm_phonecall_error](https://user-images.githubusercontent.com/226753/82219059-1134dd80-991d-11ea-8a83-d05a803ea80f.png)



**Solution:**
`crm.phonecall` and `crm.phonecall2phonecall` using the same relation name for tag_ids
Changing the name in the wizard should solve the problem