### PR TITLE
[12.0][FIX] crm_phonecall: Remove New Mail filter

### DIFF
--- a/crm_phonecall/views/crm_phonecall_view.xml
+++ b/crm_phonecall/views/crm_phonecall_view.xml
@@ -178,8 +178,6 @@
                 <separator/>
                 <filter string="To Do" name="current" domain="[('state','in',('open','pending'))]"/>
                 <separator/>
-                <filter string="New Mail" name="message_unread" domain="[('message_unread','=',True)]"/>
-                <separator/>
                 <field name="partner_id" operator="child_of"/>
                 <field name="user_id"/>
                 <field name="opportunity_id"/>


### PR DESCRIPTION
The crm_phonecall addon is implementing a filter `New Mail` with field `message_unread` (inherited by `mail.thread` mixin).

```xml
<filter string="New Mail" 
name="message_unread" domain="[('message_unread','=',True)]"/>
```

The filter itself is not working because `message_unread` is not stored in database.
Odoo Server also logs these errors on usage:

`Non-stored field crm.phonecall.message_unread cannot be searched.`

This PR is removing the New Mail filter

**The translation for `New Mail` is still available in po files. What is the correct approach to remove them?**

Thank you

