### PR TITLE
[FIX] crm_claim: Claim statusbar not clickable

### DIFF
--- a/crm_claim/views/crm_claim_views.xml
+++ b/crm_claim/views/crm_claim_views.xml
@@ -25,7 +25,11 @@
         <field name="arch" type="xml">
             <form string="Claim">
                 <header>
-                    <field name="stage_id" widget="statusbar" clickable="True" />
+                    <field
+                        name="stage_id"
+                        widget="statusbar"
+                        options="{'clickable': 1}"
+                    />
                 </header>
                 <sheet string="Claims">
                     <group>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The Claim form's statusbar is intended to be clickable, but Odoo 13 is apparently no longer compatible with `clickable="True"`. Instead, either `clickable="1"` or `options="{'clickable': 1}"` must be used. Odoo core code uses the latter, so the Claim form has been updated to match core convention.

**Current behavior before PR:**

* The Claim form's **Stage** statusbar is not clickable.

**Desired behavior after PR is merged:**

* The Claim form's **Stage** statusbar should be clickable in edit or view mode, assuming the user has write permissions to Claims.

**Steps to reproduce:**

1. Install `crm_claim` module
2. Go to **CRM > After-Sale > Claims** menu
3. Create a Claim
4. Change its **Stage** by clicking a different stage in the statusbar

**Solution:**

* The Claim form's **Stage** statusbar uses `options="{'clickable': 1}"` in order to be fully compatible with Odoo 13.