### PR TITLE
[12.0][ADD] crm_sale_lead_tag_sync : Sync CRM Lead tags with Sale Order tags

### DIFF
--- a/crm_sale_lead_tag_sync/__init__.py
+++ b/crm_sale_lead_tag_sync/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/crm_sale_lead_tag_sync/__manifest__.py
+++ b/crm_sale_lead_tag_sync/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'CRM Lead Tags Sync',
+    'summary': 'Sync CRM Lead tags with Sale Order tags',
+    'category': 'Customer Relationship Management',
+    'version': '12.0.1.0.0',
+    'author': 'Druidoo, '
+              'Moka Tourisme, '
+              'Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'website': 'https://github.com/OCA/crm',
+    'depends': [
+        'sale_crm',
+    ],
+}

--- a/crm_sale_lead_tag_sync/models/__init__.py
+++ b/crm_sale_lead_tag_sync/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order
+from . import crm_lead

--- a/crm_sale_lead_tag_sync/models/crm_lead.py
+++ b/crm_sale_lead_tag_sync/models/crm_lead.py
@@ -1,0 +1,21 @@
+# Copyright 2020 Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class CrmLead(models.Model):
+    _inherit = 'crm.lead'
+
+    def _sync_tag_ids(self):
+        """ Synchronizes tag_ids to the sale orders. """
+        for rec in self:
+            for order in rec.order_ids:
+                if order.tag_ids != rec.tag_ids:
+                    order.tag_ids = rec.tag_ids
+
+    def write(self, vals):
+        res = super().write(vals)
+        if 'tag_ids' in vals:
+            self._sync_tag_ids()
+        return res

--- a/crm_sale_lead_tag_sync/models/sale_order.py
+++ b/crm_sale_lead_tag_sync/models/sale_order.py
@@ -1,0 +1,32 @@
+# Copyright 2020 Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _sync_tag_ids(self):
+        """ Synchronizes tag_ids to the opportunity. """
+        for rec in self:
+            if not rec.opportunity_id:
+                continue
+            if rec.opportunity_id.tag_ids != rec.tag_ids:
+                rec.opportunity_id.tag_ids = rec.tag_ids
+
+    def _sync_tag_ids_from_opportunity(self):
+        """ Resets tag_ids from the related opportunity, if changed. """
+        for rec in self:
+            if not rec.opportunity_id:
+                continue
+            if rec.opportunity_id.tag_ids != rec.tag_ids:
+                rec.tag_ids = rec.opportunity_id.tag_ids
+
+    def write(self, vals):
+        res = super().write(vals)
+        if 'tag_ids' in vals:
+            self._sync_tag_ids()
+        if 'opportunity_id' in vals:
+            self._sync_tag_ids_from_opportunity()
+        return res

--- a/crm_sale_lead_tag_sync/readme/CONTRIBUTORS.rst
+++ b/crm_sale_lead_tag_sync/readme/CONTRIBUTORS.rst
@@ -1,0 +1,5 @@
+* `Druidoo <https://www.druidoo.io>`_:
+    * Iván Todorovich <ivan.todorovich@gmail.com>
+
+* `Moka Tourisme <https://www.mokatourisme.fr>`_:
+    * Grégory Schreiner

--- a/crm_sale_lead_tag_sync/readme/DESCRIPTION.rst
+++ b/crm_sale_lead_tag_sync/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Synchronize tags between Leads and Sale Orders

--- a/crm_sale_lead_tag_sync/readme/ROADMAP.rst
+++ b/crm_sale_lead_tag_sync/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+In `13.0`, use computed stored writeable fields instead.

--- a/crm_sale_lead_tag_sync/readme/USAGE.rst
+++ b/crm_sale_lead_tag_sync/readme/USAGE.rst
@@ -1,0 +1,5 @@
+Edit the tags of any lead with a linked sale order, and you'll find the
+tags automatically synchronized to the sale order.
+
+You can also edit the tags of any sale order linked to an opportunity,
+and you'll find the tags automatically synchronized to the opportunity.

--- a/crm_sale_lead_tag_sync/tests/__init__.py
+++ b/crm_sale_lead_tag_sync/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_lead

--- a/crm_sale_lead_tag_sync/tests/test_lead.py
+++ b/crm_sale_lead_tag_sync/tests/test_lead.py
@@ -1,0 +1,57 @@
+# Copyright 2020 Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class LeadCase(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.partner = self.env["res.partner"].create({
+            "name": "My test partner",
+        })
+        self.tag = self.env["crm.lead.tag"].create({
+            "name": "My tag",
+        })
+        self.lead = self.env["crm.lead"].create({
+            "name": "My lead",
+            "partner_id": self.partner.id,
+            "tag_ids": [(4, self.tag.id)],
+        })
+        self.sale_order = self.env["sale.order"].create({
+            "opportunity_id": self.lead.id,
+            "partner_id": self.partner.id,
+            "tag_ids": [(4, self.tag.id)],
+        })
+
+    def test_sync_on_lead(self):
+        """ Sale order tags are synchronized when editing lead tags """
+        tag = self.env["crm.lead.tag"].create({"name": "Lead Tag"})
+        self.lead.tag_ids = tag
+        self.assertEqual(self.sale_order.tag_ids, tag)
+
+    def test_sync_on_sale_order(self):
+        """ Lead tags are synchronized when editing sale order tags """
+        tag = self.env["crm.lead.tag"].create({"name": "Sale Order Tag"})
+        self.sale_order.tag_ids = tag
+        self.assertEqual(self.lead.tag_ids, tag)
+
+    def test_sync_on_lead_change(self):
+        """ Sale order tags are taken from new lead, if a new one is set """
+        tags = self.env["crm.lead.tag"].search([])
+        lead = self.env["crm.lead"].create({
+            "name": "New lead",
+            "partner_id": self.partner.id,
+            "tag_ids": [(4, tag_id) for tag_id in tags.ids],
+        })
+        self.sale_order.opportunity_id = lead.id
+        self.assertEqual(self.sale_order.tag_ids, tags)
+
+    def test_sale_without_lead(self):
+        """ Sale order without opportunity shouldn't synchronize anything """
+        tags = self.sale_order.tag_ids
+        opportunity = self.sale_order.opportunity_id
+        self.sale_order.opportunity_id = False
+        self.assertEqual(self.sale_order.tag_ids, tags)
+        self.sale_order.tag_ids = [(5)]
+        self.assertEqual(opportunity.tag_ids, tags)


### PR DESCRIPTION
Synchronize tags between Leads and Sale Orders

---

Edit the tags of any lead with a linked sale order, and you'll find the
tags automatically synchronized to the sale order.

You can also edit the tags of any sale order linked to an opportunity,
and you'll find the tags automatically synchronized to the opportunity.