### PR TITLE
crm_phonecall: Phonecall statusbar not clickable

### DIFF
--- a/crm_phonecall/views/crm_phonecall_view.xml
+++ b/crm_phonecall/views/crm_phonecall_view.xml
@@ -74,7 +74,7 @@
                         name="state"
                         nolabel="1"
                         widget="statusbar"
-                        clickable="True"
+                        options="{'clickable': 1}"
                     />
                 </header>
                 <sheet string="Phone Call">


### PR DESCRIPTION
The Phonecall form's statusbar is intended to be clickable, but Odoo 13 is apparently no longer compatible with clickable="True". Instead, either clickable="1" or options="{'clickable': 1}" must be used. Odoo core code uses the latter, so the Claim form has been updated to match core convention.