### PR TITLE
[12.0][FIX] crm_claim: _description fields are not translated

### DIFF
--- a/crm_claim/models/crm_claim.py
+++ b/crm_claim/models/crm_claim.py
@@ -36,9 +36,19 @@ class CrmClaim(models.Model):
 
     @api.model
     def _selection_model(self):
+
+        def _translate(src):
+            """ Custom translate function since we need to get
+                model._description translation but the default gettext _ alias
+                only search for `code` and `sql_constraint` translations
+            """
+            return self.env['ir.translation'].sudo()._get_source(
+                None, ('model', 'model_terms'), self.env.lang, src
+            )
+
         return [
-            (x, _(self.env[x]._description)) for x in APPLICABLE_MODELS
-            if x in self.env
+            (x, _translate(self.env[x]._description))
+            for x in APPLICABLE_MODELS if x in self.env
         ]
 
     name = fields.Char(


### PR DESCRIPTION
`model_ref_id` dropdown content is not properly translated

This fix add a custom translate function since we need to get `model._description` translation but the default gettext `_` alias only search for `code` and `sql_constraint` translations

Before:
![image](https://user-images.githubusercontent.com/22446243/107010475-af602080-6796-11eb-8029-00f8038b307b.png)

After:
![image](https://user-images.githubusercontent.com/22446243/107010452-a53e2200-6796-11eb-99e2-37da1716cf7f.png)
