### PR TITLE
[15.0][IMP] crm_claim: Remove unnecessary (and confusing) activity fields in views (form + tree).

### DIFF
--- a/crm_claim/i18n/crm_claim.pot
+++ b/crm_claim/i18n/crm_claim.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-09-06 08:33+0000\n"
+"PO-Revision-Date: 2022-09-06 08:33+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -49,11 +51,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:crm_claim.field_crm_claim__type_action
 #: model:ir.model.fields,field_description:crm_claim.field_crm_claim_report__type_action
 msgid "Action Type"
-msgstr ""
-
-#. module: crm_claim
-#: model_terms:ir.ui.view,arch_db:crm_claim.crm_case_claims_form_view
-msgid "Actions"
 msgstr ""
 
 #. module: crm_claim

--- a/crm_claim/i18n/es.po
+++ b/crm_claim/i18n/es.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-29 16:26+0000\n"
-"PO-Revision-Date: 2020-03-01 22:13+0000\n"
+"POT-Creation-Date: 2022-09-06 08:33+0000\n"
+"PO-Revision-Date: 2022-09-06 10:34+0200\n"
 "Last-Translator: Antonio Pérez Ruth <antonio.perez@makrin.es>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.10\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: crm_claim
 #: model:ir.model.fields,field_description:crm_claim.field_res_partner__claim_count
@@ -59,11 +59,6 @@ msgid "Action Type"
 msgstr "Tipo de acción"
 
 #. module: crm_claim
-#: model_terms:ir.ui.view,arch_db:crm_claim.crm_case_claims_form_view
-msgid "Actions"
-msgstr "Acciones"
-
-#. module: crm_claim
 #: model:ir.model.fields,field_description:crm_claim.field_crm_claim__active
 msgid "Active"
 msgstr "Activo"
@@ -75,9 +70,8 @@ msgstr "Actividades"
 
 #. module: crm_claim
 #: model:ir.model.fields,field_description:crm_claim.field_crm_claim__activity_exception_decoration
-#, fuzzy
 msgid "Activity Exception Decoration"
-msgstr "Descripción de la acción..."
+msgstr "Decoración de excepción de actividad"
 
 #. module: crm_claim
 #: model:ir.model.fields,field_description:crm_claim.field_crm_claim__activity_state
@@ -405,12 +399,12 @@ msgstr "Identificador"
 #. module: crm_claim
 #: model:ir.model.fields,field_description:crm_claim.field_crm_claim__activity_exception_icon
 msgid "Icon"
-msgstr ""
+msgstr "Icono"
 
 #. module: crm_claim
 #: model:ir.model.fields,help:crm_claim.field_crm_claim__activity_exception_icon
 msgid "Icon to indicate an exception activity."
-msgstr ""
+msgstr "Icono para indicar una actividad de excepción."
 
 #. module: crm_claim
 #: model:ir.model.fields,help:crm_claim.field_crm_claim__message_needaction
@@ -496,7 +490,6 @@ msgstr "Mensajes"
 
 #. module: crm_claim
 #: model:ir.model.fields,field_description:crm_claim.field_crm_claim__model_ref_id
-#, fuzzy
 msgid "Model Reference"
 msgstr "Referencia"
 
@@ -564,9 +557,8 @@ msgstr "Nº de días para cerrar el caso"
 
 #. module: crm_claim
 #: model:ir.model.fields,field_description:crm_claim.field_crm_claim__message_has_error_counter
-#, fuzzy
 msgid "Number of errors"
-msgstr "Número de error"
+msgstr "Número de errores"
 
 #. module: crm_claim
 #: model:ir.model.fields,help:crm_claim.field_crm_claim__message_needaction_counter
@@ -694,9 +686,8 @@ msgstr "Causas principales"
 
 #. module: crm_claim
 #: model:ir.model.fields,field_description:crm_claim.field_crm_claim__message_has_sms_error
-#, fuzzy
 msgid "SMS Delivery error"
-msgstr "Error en la entrega del mensaje"
+msgstr "Error de entrega de SMS"
 
 #. module: crm_claim
 #: model:ir.model.fields,field_description:crm_claim.field_crm_claim__team_id
@@ -796,7 +787,7 @@ msgstr "Tipo"
 #. module: crm_claim
 #: model:ir.model.fields,help:crm_claim.field_crm_claim__activity_exception_decoration
 msgid "Type of the exception activity on record."
-msgstr ""
+msgstr "Tipo de actividad de excepción en registro."
 
 #. module: crm_claim
 #: model_terms:ir.ui.view,arch_db:crm_claim.view_crm_case_claims_filter
@@ -863,15 +854,3 @@ msgstr ""
 "Puede crear etapas de reclamaciones para categorizar el estado de cada "
 "reclamación introducida en el sistema. Las etapas definen todos los pasos "
 "requeridos para la resolución de la reclamación."
-
-#~ msgid "If checked new messages require your attention."
-#~ msgstr "Si está marcado, hay nuevos mensajes que requieren su atención."
-
-#~ msgid "Overdue"
-#~ msgstr "Sobrepasado"
-
-#~ msgid "Planned"
-#~ msgstr "Fecha planificada"
-
-#~ msgid "Today"
-#~ msgstr "Hoy"

--- a/crm_claim/views/crm_claim_views.xml
+++ b/crm_claim/views/crm_claim_views.xml
@@ -10,8 +10,6 @@
                 <field name="user_id" />
                 <field name="date" />
                 <field name="stage_id" />
-                <field name="activity_date_deadline" />
-                <field name="activity_summary" />
                 <field name="categ_id" string="Type" />
                 <field name="date_deadline" invisible="1" />
                 <field name="date_closed" invisible="1" />
@@ -72,11 +70,6 @@
                                 <field name="description" colspan="4" nolabel="1" />
                             </page>
                             <page string="Follow Up" groups="base.group_user">
-                                <group colspan="2" col="2">
-                                    <separator colspan="2" string="Actions" />
-                                    <field name="activity_date_deadline" />
-                                    <field name="activity_summary" />
-                                </group>
                                 <group colspan="2" col="2" groups="base.group_no_one">
                                     <separator colspan="2" string="Dates" />
                                     <field name="create_date" />


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/crm/pull/437

Remove unnecessary (and confusing) activity fields in views (form + tree).

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT38822