### PR TITLE
[ADD] crm_industry: Propagate industries from customer to lead/opportunity

### DIFF
--- a/crm_industry/__manifest__.py
+++ b/crm_industry/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "CRM Industry",
     "summary": "Link leads/opportunities to industries",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.1.0",
     "category": "Customer Relationship Management",
     "website": "https://github.com/OCA/crm",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/crm_industry/models/crm_lead.py
+++ b/crm_industry/models/crm_lead.py
@@ -41,3 +41,29 @@ class CrmLead(models.Model):
             }
         )
         return values
+
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        if self.partner_id:
+            if self.partner_id.industry_id:
+                self.industry_id = self.partner_id.industry_id
+            if self.partner_id.secondary_industry_ids:
+                self.secondary_industry_ids = self.partner_id.secondary_industry_ids
+
+    @api.model
+    def create(self, vals):
+        if vals.get("partner_id"):
+            customer = self.env["res.partner"].browse(vals["partner_id"])
+            if customer.industry_id and not vals.get("industry_id"):
+                vals.update({"industry_id": customer.industry_id.id})
+            if customer.secondary_industry_ids and not vals.get(
+                "secondary_industry_ids"
+            ):
+                vals.update(
+                    {
+                        "secondary_industry_ids": [
+                            (6, 0, customer.secondary_industry_ids.ids)
+                        ]
+                    }
+                )
+        return super().create(vals)

--- a/crm_industry/readme/CONTRIBUTORS.rst
+++ b/crm_industry/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * Luis M. Ontalba <luis.martinez@tecnativa.com>
 * Miquel Raïch <miquel.raich@forgeflow.com>
 * Alexandre Díaz <alexandre.diaz@tecnativa.com>
+* Manuel Marquez <manuel@getmadeit.io>

--- a/crm_industry/tests/test_crm_lead.py
+++ b/crm_industry/tests/test_crm_lead.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import UserError
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
 
@@ -39,3 +40,29 @@ class TestCrmLead(TransactionCase):
         )
         self.assertEqual(partner.industry_id, lead.industry_id)
         self.assertEqual(partner.secondary_industry_ids, lead.secondary_industry_ids)
+
+    def test_propagate_industries_from_contact(self):
+        res_partner_industry = self.env["res.partner.industry"]
+        industry_1 = res_partner_industry.create({"name": "IT/Communications"})
+        industry_2 = res_partner_industry.create(
+            {"name": "AI/Machine Learning", "parent_id": industry_1.id}
+        )
+        industry_3 = res_partner_industry.create(
+            {"name": "ERP Systems", "parent_id": industry_1.id}
+        )
+        customer = self.env["res.partner"].create(
+            {
+                "name": "Test Customer",
+                "industry_id": industry_1.id,
+                "secondary_industry_ids": [
+                    (4, industry_2.id, 0),
+                    (4, industry_3.id, 0),
+                ],
+            }
+        )
+        lead_form = Form(self.env["crm.lead"])
+        lead_form.name = "Test Lead"
+        lead_form.partner_id = customer
+        lead = lead_form.save()
+        self.assertEqual(lead.industry_id, customer.industry_id)
+        self.assertEqual(lead.secondary_industry_ids, customer.secondary_industry_ids)


### PR DESCRIPTION
This PR adds onchange event over field partner_id in leads to pull the industries from customer's contact to the lead