### PR TITLE
[13.0][FIX] crm_security_group: Fix menu visibility

### DIFF
--- a/crm_security_group/security/security.xml
+++ b/crm_security_group/security/security.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="module_category_crm" model="ir.module.category">
-        <field name="name">CRM</field>
-        <field name="sequence">80</field>
-    </record>
     <record id="module_category_crm_crm" model="ir.module.category">
         <field name="name">CRM</field>
-        <field name="parent_id" ref="crm_security_group.module_category_crm" />
+        <field name="parent_id" ref="base.module_category_sales" />
     </record>
     <record id="group_crm_own_leads" model="res.groups">
         <field name="name">User: Own Documents Only</field>

--- a/crm_security_group/tests/test_crm_security.py
+++ b/crm_security_group/tests/test_crm_security.py
@@ -78,7 +78,7 @@ class TestCrmSecurity(SavepointCase):
     def test_user_sale(self):
         model = self.model_ir_ui_menu.with_user(self.sale_user)
         items = model._visible_menu_ids()
-        self.assertTrue(self.crm_menu.id in items)
+        self.assertFalse(self.crm_menu.id in items)
         self.assertTrue(self.sale_menu.id in items)
         # Crm lead checks
         crm_lead_model = self.env["crm.lead"].with_user(self.sale_user)

--- a/crm_security_group/views/menu_items.xml
+++ b/crm_security_group/views/menu_items.xml
@@ -3,7 +3,7 @@
     <record id="crm.crm_menu_root" model="ir.ui.menu">
         <field
             name="groups_id"
-            eval="[(4, ref('crm_security_group.group_crm_own_leads'))]"
+            eval="[(6,0,[ref('crm_security_group.group_crm_own_leads')])]"
         />
     </record>
     <record id="sale_crm.sale_order_menu_quotations_crm" model="ir.ui.menu">
@@ -18,7 +18,7 @@
     <record id="crm.crm_menu_report" model="ir.ui.menu">
         <field
             name="groups_id"
-            eval="[(4, ref('crm_security_group.group_crm_manager'))]"
+            eval="[(6,0,[ref('crm_security_group.group_crm_manager')])]"
         />
     </record>
     <record id="crm.crm_menu_config" model="ir.ui.menu">


### PR DESCRIPTION
Regroup permissions in `Sales` section + Fix menu visibility:
- Show CRM root menu only if user has any CRM permissions.
- Show Reporting menu from CRM only if user has any CRM permissions.

Please @pedrobaeza can you review it?

@Tecnativa TT40356