### PR TITLE
[15.0][FIX] crm_security_group: Set groups_id in menu items correctly (similar to v14)

### DIFF
--- a/crm_security_group/views/menu_items.xml
+++ b/crm_security_group/views/menu_items.xml
@@ -3,7 +3,7 @@
     <record id="crm.crm_menu_root" model="ir.ui.menu">
         <field
             name="groups_id"
-            eval="[(4, ref('crm_security_group.group_crm_own_leads')),(3, ref('sales_team.group_sale_salesman')),(3, ref('sales_team.group_sale_manager'))]"
+            eval="[(6,0,[ref('crm_security_group.group_crm_own_leads')])]"
         />
     </record>
     <record id="sale_crm.sale_order_menu_quotations_crm" model="ir.ui.menu">
@@ -18,7 +18,7 @@
     <record id="crm.crm_menu_report" model="ir.ui.menu">
         <field
             name="groups_id"
-            eval="[(4, ref('crm_security_group.group_crm_manager')),(3, ref('sales_team.group_sale_salesman'))]"
+            eval="[(6,0,[ref('crm_security_group.group_crm_manager')])]"
         />
     </record>
     <record id="crm.crm_menu_config" model="ir.ui.menu">


### PR DESCRIPTION
Set `groups_id` in menu items correctly (similar to v14)

Please @pedrobaeza can you review it?

@Tecnativa TT40356

Sorry, I wanted to wait for these changes to be merged in v14 (https://github.com/OCA/crm/pull/453) and then add them to the commit history in v15 migration PR.