### PR TITLE
[IMP] crm_lead_product: Make product_qty float

### DIFF
--- a/crm_lead_product/models/crm_lead_line.py
+++ b/crm_lead_product/models/crm_lead_line.py
@@ -30,7 +30,12 @@ class CrmLeadLine(models.Model):
     product_tmpl_id = fields.Many2one(
         "product.template", string="Product Template", index=True
     )
-    product_qty = fields.Integer(string="Product Quantity", default=1, required=True)
+    product_qty = fields.Float(
+        string="Product Quantity",
+        digits='Product Unit of Measure',
+        default=1.0,
+        required=True
+    )
     uom_id = fields.Many2one("uom.uom", string="Unit of Measure", readonly=True)
     price_unit = fields.Float(string="Price Unit")
     planned_revenue = fields.Float(


### PR DESCRIPTION
Product quantity being integer is not consistent with all other similar objects (sale.order.line, purchase.order.line, account.move.line) and does not really make much sense.