### PR TITLE
[15.0][FIX] crm_phonecall: Fix error element "schedule_meeting" not found in parent view

### DIFF
--- a/crm_phonecall/views/res_partner_view.xml
+++ b/crm_phonecall/views/res_partner_view.xml
@@ -10,7 +10,7 @@
         />
         <field eval="18" name="priority" />
         <field name="arch" type="xml">
-            <button name="schedule_meeting" position="before">
+            <div name="button_box" position="inside">
                 <button
                     class="oe_stat_button"
                     context="{'search_default_partner_id': active_id}"
@@ -20,7 +20,7 @@
                 >
                     <field name="phonecall_count" string="Calls" widget="statinfo" />
                 </button>
-            </button>
+            </div>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
cc @Tecnativa 

The parent view has not the element
https://github.com/odoo/odoo/blob/916694786af63ae8d93629041ade73f7d956e0b7/addons/crm/views/res_partner_views.xml#L32

ping @carlosdauden @ernesto-garcia-tecnativa 