### PR TITLE
[FIX] klaviyo_crm: allow installing requirements on python 3.5

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -3,7 +3,7 @@ _commit: v1.14.2
 _src_path: https://github.com/OCA/oca-addons-repo-template.git
 ci: GitHub
 dependency_installation_mode: PIP
-generate_requirements_txt: true
+generate_requirements_txt: false
 github_check_license: true
 github_ci_extra_env: {}
 github_enable_codecov: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,12 +28,6 @@ repos:
     rev: 3.1.8
     hooks:
       - id: setuptools-odoo-make-default
-      - id: setuptools-odoo-get-requirements
-        args:
-          - --output
-          - requirements.txt
-          - --header
-          - "# generated from manifests external_dependencies"
   - repo: https://github.com/OCA/mirrors-flake8
     rev: v3.4.1
     hooks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # generated from manifests external_dependencies
 dataclasses
-klaviyo_api
+klaviyo_api; python_version >= '3.6'


### PR DESCRIPTION
There's no possible installation candidate of klaviyo-api for Python 3.5, which is a common interpreter for v12 deployments.

With this patch, these environments are able to run `-r requirements.txt` again on this file.

@moduon MT-2631