### PR TITLE
[16.0] [FIX] crm_claim form layout

### DIFF
--- a/crm_claim/views/crm_claim_views.xml
+++ b/crm_claim/views/crm_claim_views.xml
@@ -40,63 +40,58 @@
                         <field name="priority" widget="priority" />
                         <field name="date_deadline" />
                     </group>
-                    <group colspan="4" col="4">
-                        <notebook>
-                            <page string="Claim Description">
-                                <group colspan="2" col="2" groups="base.group_user">
-                                    <separator colspan="2" string="Claim Reporter" />
-                                    <field name="partner_id" string="Partner" />
-                                    <field name="partner_phone" />
-                                    <field name="email_from" widget="email" />
-                                </group>
-                                <group colspan="2" col="2" groups="base.group_user">
-                                    <separator colspan="2" string="Responsibilities" />
-                                    <field
-                                        name="user_id"
-                                        context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'base.group_sale_salesman_all_leads']}"
-                                    />
-                                    <field name="user_fault" />
-                                    <field
-                                        name="categ_id"
-                                        options="{'no_create': True, 'no_open': True}"
-                                    />
-                                    <field name="team_id" />
-                                    <field name="model_ref_id" widget="reference" />
-                                </group>
-                                <separator
-                                    colspan="4"
-                                    string="Claim/Action Description"
-                                    groups="base.group_user"
+                    <notebook>
+                        <page string="Claim Description">
+                            <group colspan="2" col="2" groups="base.group_user">
+                                <separator colspan="2" string="Claim Reporter" />
+                                <field name="partner_id" string="Partner" />
+                                <field name="partner_phone" />
+                                <field name="email_from" widget="email" />
+                            </group>
+                            <group colspan="2" col="2" groups="base.group_user">
+                                <separator colspan="2" string="Responsibilities" />
+                                <field
+                                    name="user_id"
+                                    context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'base.group_sale_salesman_all_leads']}"
                                 />
-                                <field name="description" colspan="4" nolabel="1" />
-                            </page>
-                            <page string="Follow Up" groups="base.group_user">
-                                <group colspan="2" col="2" groups="base.group_no_one">
-                                    <separator colspan="2" string="Dates" />
-                                    <field name="create_date" />
-                                    <field name="date_closed" invisible="1" />
-                                    <field name="write_date" />
-                                </group>
-                                <group colspan="2" col="2">
-                                    <separator colspan="2" string="Root Causes" />
-                                    <field name="cause" colspan="2" nolabel="1" />
-                                </group>
-                                <group colspan="2" col="2">
-                                    <separator
-                                        colspan="2"
-                                        string="Resolution Actions"
-                                    />
-                                    <field name="type_action" />
-                                    <field
-                                        name="resolution"
-                                        colspan="2"
-                                        nolabel="1"
-                                        placeholder="Action Description..."
-                                    />
-                                </group>
-                            </page>
-                        </notebook>
-                    </group>
+                                <field name="user_fault" />
+                                <field
+                                    name="categ_id"
+                                    options="{'no_create': True, 'no_open': True}"
+                                />
+                                <field name="team_id" />
+                                <field name="model_ref_id" widget="reference" />
+                            </group>
+                            <separator
+                                colspan="4"
+                                string="Claim/Action Description"
+                                groups="base.group_user"
+                            />
+                            <field name="description" colspan="4" nolabel="1" />
+                        </page>
+                        <page string="Follow Up" groups="base.group_user">
+                            <group colspan="2" col="2" groups="base.group_no_one">
+                                <separator colspan="2" string="Dates" />
+                                <field name="create_date" />
+                                <field name="date_closed" invisible="1" />
+                                <field name="write_date" />
+                            </group>
+                            <group colspan="2" col="2">
+                                <separator colspan="2" string="Root Causes" />
+                                <field name="cause" colspan="2" nolabel="1" />
+                            </group>
+                            <group colspan="2" col="2">
+                                <separator colspan="2" string="Resolution Actions" />
+                                <field name="type_action" />
+                                <field
+                                    name="resolution"
+                                    colspan="2"
+                                    nolabel="1"
+                                    placeholder="Action Description..."
+                                />
+                            </group>
+                        </page>
+                    </notebook>
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids" widget="mail_followers" />


### PR DESCRIPTION
This fixes the broken view as a result of the `group` wrapper on the `notebook` tag:

![image](https://user-images.githubusercontent.com/4799405/231238023-b300c334-e3bf-4288-a1c4-5e07106c4e10.png)
