### PR TITLE
[IMP] crm_lead_currency: show customer currency only for opportunities

### DIFF
--- a/crm_lead_currency/views/crm_lead_views.xml
+++ b/crm_lead_currency/views/crm_lead_views.xml
@@ -6,14 +6,17 @@
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.crm_lead_view_form" />
         <field name="arch" type="xml">
-            <field name="partner_id" position="before">
+            <xpath
+                expr="//group[@name='opportunity_partner']//field[@name='partner_id']"
+                position="before"
+            >
                 <field name="customer_currency_id" />
                 <field name="is_same_currency" invisible="1" />
                 <field
                     name="amount_customer_currency"
                     attrs="{'invisible': [('is_same_currency', '=', True)]}"
                 />
-            </field>
+            </xpath>
             <field name="expected_revenue" position="attributes">
                 <attribute name="attrs">
                     {'readonly': [('is_same_currency', '=', False)]}


### PR DESCRIPTION
 Update fields customer_currency_id  to be shown in the views of both, a lead or an opportunity.
 
![image](https://user-images.githubusercontent.com/77296309/236870264-c0b419ee-6b50-4b23-9295-cfb12112cf55.png)
![image](https://user-images.githubusercontent.com/77296309/236870290-c93ead20-e52b-4163-8092-eac7d31989e9.png)
