### PR TITLE
[15.0][IMP] crm_partner_assign: move fields before user_id

### DIFF
--- a/crm_partner_assign/readme/CONTRIBUTORS.rst
+++ b/crm_partner_assign/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
 * Rafael Blasco (`Moduon <https://www.moduon.team/>`__)
+* Emilio Pascual (`Moduon <https://www.moduon.team/>`__)

--- a/crm_partner_assign/views/crm_lead_view.xml
+++ b/crm_partner_assign/views/crm_lead_view.xml
@@ -8,17 +8,7 @@
         <field name="inherit_id" ref="crm.crm_lead_view_form" />
         <field name="arch" type="xml">
             <!-- LEAD -->
-            <xpath
-                expr="//group[@name='lead_partner']/field[@name='website']"
-                position="before"
-            >
-                <field name="partner_contact_assigned_id" />
-                <field name="partner_assigned_id" />
-            </xpath>
-            <xpath
-                expr="//group[@name='opportunity_partner']/label[@for='email_from']"
-                position="before"
-            >
+            <xpath expr="//field[@name='user_id']" position="before">
                 <field name="partner_contact_assigned_id" />
                 <field name="partner_assigned_id" />
             </xpath>
@@ -30,7 +20,7 @@
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.crm_case_tree_view_leads" />
         <field name="arch" type="xml">
-            <xpath expr="//tree/field[@name='country_id']" position="after">
+            <xpath expr="//tree/field[@name='user_id']" position="before">
                 <field name="partner_assigned_id" optional="hide" />
                 <field name="partner_contact_assigned_id" optional="hide" />
             </xpath>
@@ -42,7 +32,7 @@
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.crm_case_tree_view_oppor" />
         <field name="arch" type="xml">
-            <xpath expr="//tree/field[@name='country_id']" position="after">
+            <xpath expr="//tree/field[@name='user_id']" position="before">
                 <field name="partner_assigned_id" optional="hide" />
                 <field name="partner_contact_assigned_id" optional="hide" />
             </xpath>


### PR DESCRIPTION
Fields partner contact assigned and partner assigned aren't related to customer. They shouldn't be before phone or email in views.

@moduon MT-3175 @rafaelbn @Shide

Opportunities:

![image](https://github.com/OCA/crm/assets/53056345/64bffbd4-f5ec-432d-bee1-a227db78fef8)

Leads:

![image](https://github.com/OCA/crm/assets/53056345/9e68cdd9-5c7f-46db-9121-01545154cc5e)
