### PR TITLE
[14.0][TEMP] crm_location_nuts: do not run tests as it makes all CI pipelines to fail

### DIFF
--- a/crm_location_nuts/tests/__init__.py
+++ b/crm_location_nuts/tests/__init__.py
@@ -1,3 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from . import test_crm_location_nuts
+# FIXME: temporarily disable tests while issue below is not solved.
+#  https://github.com/OCA/partner-contact/issues/1557
+# from . import test_crm_location_nuts


### PR DESCRIPTION
`crm_location_nuts` re-use the test class from `base_location_nuts`.
Same temporary fix that https://github.com/OCA/partner-contact/pull/1560

Related to initial issue https://github.com/OCA/partner-contact/issues/1557