### PR TITLE
[15.0] crm_phonecall: improve context in phone calls button

### DIFF
--- a/crm_phonecall/views/res_partner_view.xml
+++ b/crm_phonecall/views/res_partner_view.xml
@@ -13,7 +13,7 @@
             <div name="button_box" position="inside">
                 <button
                     class="oe_stat_button"
-                    context="{'search_default_partner_id': active_id}"
+                    context="{'search_default_partner_id': active_id, 'default_partner_id': active_id}"
                     icon="fa-phone"
                     name="%(crm_phonecall.crm_case_categ_phone_incoming0)d"
                     type="action"


### PR DESCRIPTION
This change allows to autocomplete contact when user belongs to group **"Enable form view for phone calls"** and he is trying to create a phone call from contact form.