### PR TITLE
[15.0][FIX] crm_phonecall: allow salesman to schedule a call

### DIFF
--- a/crm_phonecall/security/ir.model.access.csv
+++ b/crm_phonecall/security/ir.model.access.csv
@@ -6,3 +6,4 @@ access_crm_phonecall_report_user,crm.phonecall.report.user,model_crm_phonecall_r
 access_crm_phonecall_report_manager,crm.phonecall.report,model_crm_phonecall_report,sales_team.group_sale_manager,1,1,1,1
 access_crm_phonecall_partner_manager,crm.phonecall.partner.manager,model_crm_phonecall,base.group_partner_manager,1,1,1,1
 access_crm_phonecall2phonecall,access_crm_phonecall2phonecall,model_crm_phonecall2phonecall,base.group_user,1,0,0,0
+access_crm_phonecall2phonecall_salesman,access_crm_phonecall2phonecall,model_crm_phonecall2phonecall,sales_team.group_sale_salesman,1,1,1,0


### PR DESCRIPTION
Without this permission a simple salesman can't create scheduled calls because has no permission to create.