### PR TITLE
[16.0][FIX] crm_claim: Delete create method from crm.claim

### DIFF
--- a/crm_claim/models/crm_claim.py
+++ b/crm_claim/models/crm_claim.py
@@ -143,13 +143,6 @@ class CrmClaim(models.Model):
         if self.stage_id:
             self.team_id = self.categ_id.team_id
 
-    @api.model
-    def create(self, values):
-        ctx = self.env.context.copy()
-        if values.get("team_id") and not ctx.get("default_team_id"):
-            ctx["default_team_id"] = values.get("team_id")
-        return super(CrmClaim, self.with_context(context=ctx)).create(values)
-
     def copy(self, default=None):
         default = dict(
             default or {},


### PR DESCRIPTION
It's setting a context when creating records for the default team_id and it's not necessary, it's redundant because the team_id field already has a default that defines it. This code is not necessary.

cc @Tecnativa TT49102

@carolinafernandez-tecnativa @pedrobaeza please review