### PR TITLE
[16.0][FIX] crm_won_restrict_per_stage: Add ValidationError to onchange to prevent display incorrect UX changes

### DIFF
--- a/crm_won_restrict_per_stage/README.rst
+++ b/crm_won_restrict_per_stage/README.rst
@@ -90,13 +90,13 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-.. |maintainer-carolina-fernandez| image:: https://github.com/carolina-fernandez.png?size=40px
-    :target: https://github.com/carolina-fernandez
-    :alt: carolina-fernandez
+.. |maintainer-carolinafernandez-tecnativa| image:: https://github.com/carolinafernandez-tecnativa.png?size=40px
+    :target: https://github.com/carolinafernandez-tecnativa
+    :alt: carolinafernandez-tecnativa
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-carolina-fernandez| 
+|maintainer-carolinafernandez-tecnativa| 
 
 This module is part of the `OCA/crm <https://github.com/OCA/crm/tree/16.0/crm_won_restrict_per_stage>`_ project on GitHub.
 

--- a/crm_won_restrict_per_stage/__manifest__.py
+++ b/crm_won_restrict_per_stage/__manifest__.py
@@ -11,5 +11,5 @@
     "depends": ["crm"],
     "data": ["views/crm_lead_views.xml", "views/crm_stage_views.xml"],
     "installable": True,
-    "maintainers": ["carolina-fernandez"],
+    "maintainers": ["carolinafernandez-tecnativa"],
 }

--- a/crm_won_restrict_per_stage/models/crm_lead.py
+++ b/crm_won_restrict_per_stage/models/crm_lead.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Tecnativa - Carolina Fernandez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -9,6 +9,23 @@ class CrmStage(models.Model):
     _inherit = "crm.lead"
 
     show_won_button = fields.Boolean(related="stage_id.show_won_button")
+
+    @api.onchange("stage_id")
+    def _onchange_stage_id(self):
+        """Do it this way for avoiding a UI glitch if we let act
+        the exception in the write, as the stage is changed in the
+        interface, but the message appears and the record is kept
+        unsaved.
+        """
+        for item in self:
+            if (
+                item != item._origin
+                and item.stage_id.is_won
+                and not item._origin.stage_id.show_won_button
+            ):
+                raise ValidationError(
+                    _("You can't change to this stage from the current stage.")
+                )
 
     def write(self, vals):
         for rec in self:

--- a/crm_won_restrict_per_stage/static/description/index.html
+++ b/crm_won_restrict_per_stage/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -435,7 +434,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/carolina-fernandez"><img alt="carolina-fernandez" src="https://github.com/carolina-fernandez.png?size=40px" /></a></p>
+<p><a class="reference external image-reference" href="https://github.com/carolinafernandez-tecnativa"><img alt="carolinafernandez-tecnativa" src="https://github.com/carolinafernandez-tecnativa.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/crm/tree/16.0/crm_won_restrict_per_stage">OCA/crm</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/crm_won_restrict_per_stage/tests/test_crm_lead.py
+++ b/crm_won_restrict_per_stage/tests/test_crm_lead.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo.exceptions import ValidationError
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
 
@@ -13,10 +14,16 @@ class TestCrmStage(TransactionCase):
         cls.stage_new = cls.env.ref("crm.stage_lead1")
         cls.stage_won = cls.env.ref("crm.stage_lead4")
 
-    def test_change_crm_stage_won_without_show_button(self):
+    def test_change_crm_stage_won_without_show_button_01(self):
         self.stage_new.show_won_button = False
         with self.assertRaises(ValidationError):
             self.crm_lead.stage_id = self.stage_won
+
+    def test_change_crm_stage_won_without_show_button_02(self):
+        self.stage_new.show_won_button = False
+        lead_form = Form(self.crm_lead)
+        with self.assertRaises(ValidationError):
+            lead_form.stage_id = self.stage_won
 
     def test_change_crm_stage_to_won_with_show_button(self):
         self.stage_new.show_won_button = True


### PR DESCRIPTION
Add ValidationError to onchange to prevent display incorrect UX changes (stage)

**Before**
![antes](https://github.com/OCA/crm/assets/4117568/50abe31b-2b9a-4fd4-bef2-af303e2ef7ae)

**After**
![despues](https://github.com/OCA/crm/assets/4117568/606299cc-7bb6-4fa2-a82b-534994c0207b)

Please @pedrobaeza can you review it?

@Tecnativa TT49558