### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/crm_lead_currency/__manifest__.py
+++ b/crm_lead_currency/__manifest__.py
@@ -10,7 +10,7 @@
     ],
     "version": "14.0.1.0.1",
     "license": "AGPL-3",
-    "author": "Camptocamp SA,Odoo Community Association (OCA),Vauxoo",
+    "author": "Camptocamp,Odoo Community Association (OCA),Vauxoo",
     "website": "https://github.com/OCA/crm",
     "depends": [
         "crm",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.