### PR TITLE
[12.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/crm_lead_currency/__manifest__.py
+++ b/crm_lead_currency/__manifest__.py
@@ -7,7 +7,7 @@
         On leads/opportunities, add the amount in the customer's currency.""",
     'version': '12.0.1.0.1',
     'license': 'AGPL-3',
-    'author': 'Camptocamp SA,Odoo Community Association (OCA)',
+    'author': 'Camptocamp,Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/crm',
     'depends': [
         'crm',


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 12.0.