### PR TITLE
[15.0][FIX] crm_project: Don't remove old lead, but archive

### DIFF
--- a/crm_project/tests/test_crm_project.py
+++ b/crm_project/tests/test_crm_project.py
@@ -45,4 +45,4 @@ class TestCrmProject(common.TransactionCase):
         self.assertEqual(task.email_cc, "cc@example.org")
         self.assertEqual(task.partner_id.name, "Test partner")
         self.assertEqual(task.project_id, self.project)
-        self.assertFalse(self.lead.exists())
+        self.assertFalse(self.lead.active)

--- a/crm_project/wizard/crm_lead_convert2task.py
+++ b/crm_project/wizard/crm_lead_convert2task.py
@@ -49,8 +49,8 @@ class CrmLeadConvert2Task(models.TransientModel):
             [("res_model", "=", "crm.lead"), ("res_id", "=", lead.id)]
         )
         attachments.write({"res_model": "project.task", "res_id": task.id})
-        # remove the lead
-        lead.unlink()
+        # archive the lead (can't be unlinked by plain salesmen)
+        lead.active = False
         # return the action to go to the form view of the new Task
         view = self.env.ref("project.view_task_form2")
         return {


### PR DESCRIPTION
Plain salesmen can't unlink leads, so let's archive it instead, as it was in previous versions.

@Tecnativa TT50262