### PR TITLE
[16.0][FIX] crm_salesperson_planner: Fix tests (Add freeze_time decorator to make it more resilient)

### DIFF
--- a/crm_salesperson_planner/tests/test_crm_salesperson_planner_visit_template.py
+++ b/crm_salesperson_planner/tests/test_crm_salesperson_planner_visit_template.py
@@ -4,6 +4,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 from datetime import timedelta
 
+from freezegun import freeze_time
+
 from odoo import exceptions, fields
 from odoo.tests import common
 from odoo.tools import mute_logger
@@ -194,6 +196,7 @@ class TestCrmSalespersonPlannerVisitTemplate(common.TransactionCase):
         first_visit.unlink()
         self.assertEqual(len(visit_template.visit_ids), 9)
 
+    @freeze_time("2024-01-01 08:00")
     def test_05_repeat_weeks(self):
         self.visit_template_base.write(
             {
@@ -220,6 +223,7 @@ class TestCrmSalespersonPlannerVisitTemplate(common.TransactionCase):
             fields.Date.from_string("2024-07-02"),
         )
 
+    @freeze_time("2024-01-01 08:00")
     def test_06_repeat_months_count_01(self):
         self.visit_template_base.write(
             {
@@ -248,6 +252,7 @@ class TestCrmSalespersonPlannerVisitTemplate(common.TransactionCase):
             fields.Date.from_string("2024-05-01"),
         )
 
+    @freeze_time("2024-01-01 08:00")
     def test_06_repeat_months_count_02(self):
         self.visit_template_base.write(
             {
@@ -276,6 +281,7 @@ class TestCrmSalespersonPlannerVisitTemplate(common.TransactionCase):
             fields.Date.from_string("2024-05-01"),
         )
 
+    @freeze_time("2024-01-01 08:00")
     def test_06_repeat_months_count_03(self):
         self.visit_template_base.write(
             {
@@ -305,6 +311,7 @@ class TestCrmSalespersonPlannerVisitTemplate(common.TransactionCase):
             fields.Date.from_string("2024-05-06"),
         )
 
+    @freeze_time("2024-01-01 08:00")
     def test_07_repeat_yearly_count_01(self):
         self.visit_template_base.write(
             {


### PR DESCRIPTION
Fix tests (Add `freeze_time` decorator to make it more resilient)

Fixes https://github.com/OCA/crm/issues/589

@Tecnativa