### PR TITLE
[16.0][FIX] crm_security_group : crm_team full access for crm_manager

### DIFF
--- a/crm_security_group/security/ir.model.access.csv
+++ b/crm_security_group/security/ir.model.access.csv
@@ -1,7 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_crm_lead_user,crm.lead.user,crm.model_crm_lead,crm_security_group.group_crm_own_leads,1,1,1,0
 access_crm_team_user,crm.team.user,sales_team.model_crm_team,crm_security_group.group_crm_own_leads,1,0,0,0
-access_crm_team_manager,crm.team.manager,sales_team.model_crm_team,crm_security_group.group_crm_own_leads,1,1,1,1
+access_crm_team_manager,crm.team.manager,sales_team.model_crm_team,crm_security_group.group_crm_manager,1,1,1,1
 access_crm_stage_manager,crm.stage.manager,crm.model_crm_stage,crm_security_group.group_crm_manager,1,1,1,1
 access_crm_tag_own_leads,sale_team.crm.tag.own.leads,sales_team.model_crm_tag,crm_security_group.group_crm_own_leads,1,1,1,0
 access_crm_tag_manager,sale_team.crm.tag.manager,sales_team.model_crm_tag,crm_security_group.group_crm_manager,1,1,1,1


### PR DESCRIPTION
CRM teams (called Sales Teams) permissions access are not fit as usual, it might be a typo ?

**At the moment** 

CRM base user (User : Own documents Only + User : All documents) can fully modified `crm_team`

**With this PR**

CRM base user (User : Own documents Only + User : All documents) can read  `crm_team`
CRM manager (Administrator) can fully modified  `crm_team`

What do you think @victoralmau ?