### PR TITLE
[17.0][IMP] crm_lead_code: space get removed when other view changes name field

### DIFF
--- a/crm_lead_code/views/crm_lead_view.xml
+++ b/crm_lead_code/views/crm_lead_view.xml
@@ -48,7 +48,7 @@
         <field name="inherit_id" ref="crm.crm_case_kanban_view_leads" />
         <field name="arch" type="xml">
             <field name="name" position="before">
-                <field name="code" />&amp;nbsp;
+                <field name="code" /><span class="p-1" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
I have another module which extends the same view like this: 

```
    <record id="crm_case_kanban_view_leads" model="ir.ui.view">
        <field name="name">crm.show.fields</field>
        <field name="model">crm.lead</field>
        <field name="inherit_id" ref="crm.crm_case_kanban_view_leads" />
        <field name="arch" type="xml">
            <field name="name" position="attributes">
                <attribute name="invisible">1</attribute>
            </field>
            <field name="name" position="after">
                <field name="display_name" />
            </field>
        </field>
    </record>
```

This causes that the space (&amp;nbsp;) after the code field is somehow removed. 
![image](https://github.com/user-attachments/assets/427512cd-81d9-41b1-9223-1df3388a72c2)
![image](https://github.com/user-attachments/assets/679c73fb-7141-4f17-a5be-e1ed0c03869f)

This change prevents this side effect.


