### PR TITLE
[17.0]][FIX] crm_phonecall: deprecated active_id in expressions

### DIFF
--- a/crm_phonecall/report/crm_phonecall_report_view.xml
+++ b/crm_phonecall/report/crm_phonecall_report_view.xml
@@ -148,7 +148,9 @@
         <field name="name">Phone Calls Analysis</field>
         <field name="res_model">crm.phonecall.report</field>
         <field name="view_mode">pivot,graph</field>
-        <field name="context">{'search_default_team_id': active_id}</field>
+        <field name="context">
+            {'search_default_team_id': context.get('active_id')}
+        </field>
     </record>
     <menuitem
         action="crm_phonecall_report_action"

--- a/crm_phonecall/views/res_partner_view.xml
+++ b/crm_phonecall/views/res_partner_view.xml
@@ -9,7 +9,7 @@
             <div name="button_box" position="inside">
                 <button
                     class="oe_stat_button"
-                    context="{'search_default_partner_id': active_id}"
+                    context="{'search_default_partner_id': context.get('active_id')}"
                     icon="fa-phone"
                     name="%(crm_phonecall.crm_case_categ_phone_incoming0)d"
                     type="action"


### PR DESCRIPTION
[active_id in view expressions is deprecated](https://github.com/odoo/odoo/blob/f6fc5f889d041e471ec3af0fa9ec931e00923be3/odoo/addons/base/models/ir_ui_view.py#L2912-L2913)