### PR TITLE
[16.0][IMP] crm_project_create: Archive or reactive the project and its analytical account from lead.

### DIFF
--- a/crm_project_create/README.rst
+++ b/crm_project_create/README.rst
@@ -31,6 +31,9 @@ CRM Project Create
 This module extends the functionality of crm and project and allow you
 to create a project from opportunity or lead.
 
+It also allows archiving or reactivating the project and its analytical
+account from the lead.
+
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
    Only for development or testing purpose, do not use in production.
@@ -89,6 +92,7 @@ Contributors
 ------------
 
 -  Emilio Pascual (`Moduon <https://www.moduon.team/>`__)
+-  Eduardo López (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 -----------

--- a/crm_project_create/models/crm_lead.py
+++ b/crm_project_create/models/crm_lead.py
@@ -8,3 +8,11 @@ class CrmLead(models.Model):
     _inherit = "crm.lead"
 
     project_id = fields.Many2one("project.project", string="Project")
+
+    def toggle_active(self):
+        """Archive or reactivate the project and their analytic account on lead toggle."""
+        res = super().toggle_active()
+        for lead in self.filtered(lambda l: l.project_id):
+            lead.sudo().project_id.active = lead.active
+            lead.sudo().project_id.analytic_account_id.active = lead.active
+        return res

--- a/crm_project_create/readme/CONTRIBUTORS.md
+++ b/crm_project_create/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 -   Emilio Pascual ([Moduon](https://www.moduon.team/))
+-   Eduardo López ([Moduon](https://www.moduon.team/))

--- a/crm_project_create/readme/DESCRIPTION.md
+++ b/crm_project_create/readme/DESCRIPTION.md
@@ -1,1 +1,3 @@
 This module extends the functionality of crm and project and allow you to create a project from opportunity or lead.
+
+It also allows archiving or reactivating the project and its analytical account from the lead.

--- a/crm_project_create/static/description/index.html
+++ b/crm_project_create/static/description/index.html
@@ -372,6 +372,8 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/crm/tree/16.0/crm_project_create"><img alt="OCA/crm" src="https://img.shields.io/badge/github-OCA%2Fcrm-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/crm-16-0/crm-16-0-crm_project_create"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/crm&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module extends the functionality of crm and project and allow you
 to create a project from opportunity or lead.</p>
+<p>It also allows archiving or reactivating the project and its analytical
+account from the lead.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.
@@ -436,6 +438,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>Emilio Pascual (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
+<li>Eduardo López (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Hello,
This pull request adds the functionality that when archiving or unarchiving an opportunity, its associated projects and analytical accounts are also archived or unarchived. It also works when a lead is lost.


TODO: video

@moduon MT-8265