### PR TITLE
[17.0][FIX] crm_salesperson_planner: fix unit tests

### DIFF
--- a/crm_salesperson_planner/tests/test_crm_salesperson_planner_visit_template.py
+++ b/crm_salesperson_planner/tests/test_crm_salesperson_planner_visit_template.py
@@ -4,6 +4,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 from datetime import timedelta
 
+from freezegun import freeze_time
+
 from odoo import exceptions, fields
 from odoo.tests import common
 from odoo.tools import mute_logger
@@ -226,6 +228,7 @@ class TestCrmSalespersonPlannerVisitTemplate(common.TransactionCase):
             fields.Date.from_string(filtered_tue_dates[len(filtered_tue_dates) - 1]),
         )
 
+    @freeze_time("2024-11-01")
     def test_06_repeat_months_count_01(self):
         self.visit_template_base.write(
             {
@@ -254,6 +257,7 @@ class TestCrmSalespersonPlannerVisitTemplate(common.TransactionCase):
             fields.Date.from_string("2024-05-01"),
         )
 
+    @freeze_time("2024-11-01")
     def test_06_repeat_months_count_02(self):
         self.visit_template_base.write(
             {
@@ -282,6 +286,7 @@ class TestCrmSalespersonPlannerVisitTemplate(common.TransactionCase):
             fields.Date.from_string("2024-05-01"),
         )
 
+    @freeze_time("2024-11-01")
     def test_06_repeat_months_count_03(self):
         self.visit_template_base.write(
             {

--- a/crm_salesperson_planner/views/crm_salesperson_planner_visit_views.xml
+++ b/crm_salesperson_planner/views/crm_salesperson_planner_visit_views.xml
@@ -24,17 +24,20 @@
                     type="object"
                     invisible="state not in ['cancel','incident', 'done']"
                     icon="fa-undo"
+                    title="Draft"
                 />
                 <button
                     name="action_confirm"
                     type="object"
                     icon="fa-calendar text-success"
+                    title="Confirm"
                     invisible="state != 'draft'"
                 />
                 <button
                     name="action_done"
                     type="object"
                     icon="fa-check"
+                    title="Done"
                     invisible="state != 'confirm'"
                 />
                 <button


### PR DESCRIPTION
- Fix the error: "The date can't be earlier than today."
- Remove warnings for buttons with the icons "fa-undo", "fa-calendar text-success", and "fa-check" due to missing titles ("A button with an icon attribute must have a title in its tag, parents, descendants, or have text")