### PR TITLE
[18.0][FIX] crm_stage_probability: add forcecreate='False'

### DIFF
--- a/crm_stage_probability/data/crm_stage.xml
+++ b/crm_stage_probability/data/crm_stage.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo noupdate="1">
-    <record model="crm.stage" id="crm.stage_lead1">
+    <record model="crm.stage" id="crm.stage_lead1" forcecreate="False">
         <field name="on_change" eval="True" />
         <field name="probability">10</field>
     </record>
-    <record model="crm.stage" id="crm.stage_lead2">
+    <record model="crm.stage" id="crm.stage_lead2" forcecreate="False">
         <field name="on_change" eval="True" />
         <field name="probability">30</field>
     </record>
-    <record model="crm.stage" id="crm.stage_lead3">
+    <record model="crm.stage" id="crm.stage_lead3" forcecreate="False">
         <field name="on_change" eval="True" />
         <field name="probability">70</field>
     </record>
-    <record model="crm.stage" id="crm.stage_lead4">
+    <record model="crm.stage" id="crm.stage_lead4" forcecreate="False">
         <field name="on_change" eval="True" />
         <field name="probability">100</field>
     </record>


### PR DESCRIPTION
In the CRM module, Odoo set forcecreate="False" for stage_lead1, stage_lead2, stage_lead3, and stage_lead4. This ensures that when updating the module, these stages are not recreated if they have been deleted.

This PR adds the same parameter to prevent the following errors:
![image](https://github.com/user-attachments/assets/d61adc5f-14ad-4873-9074-6753ca762ee1)
![image](https://github.com/user-attachments/assets/1312b400-cf02-4ca9-9727-23cb88d35e5a)


