### PR TITLE
[18.0][FIX] crm_phonecall: prevent access error to ir.actions.act_window for normal users

### DIFF
--- a/crm_phonecall/models/crm_lead.py
+++ b/crm_phonecall/models/crm_lead.py
@@ -25,8 +25,9 @@ class CrmLead(models.Model):
 
     def button_open_phonecall(self):
         self.ensure_one()
-        action = self.env.ref("crm_phonecall.crm_case_categ_phone_incoming0")
-        action_dict = action.read()[0] if action else {}
+        action_dict = self.env["ir.actions.act_window"]._for_xml_id(
+            "crm_phonecall.crm_case_categ_phone_incoming0"
+        )
         action_dict["context"] = safe_eval(action_dict.get("context", "{}"))
         action_dict["context"].update(
             {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8d53f4bb-5867-4790-bfcd-0b39da42ad68)

Complementary to migration to V18.

@victoralmau @juancarlosonate-tecnativa @pedrobaeza @BhaveshHeliconia could you please review this?