### PR TITLE
[15.0][IMP] crm_multicompany_reporting_currency

### DIFF
--- a/crm_multicompany_reporting_currency/README.rst
+++ b/crm_multicompany_reporting_currency/README.rst
@@ -59,6 +59,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Maksym Yankin <maksym.yankin@camptocamp.com>
+* Italo Lopes <italo.lopes@camptocamp.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/crm_multicompany_reporting_currency/__manifest__.py
+++ b/crm_multicompany_reporting_currency/__manifest__.py
@@ -10,6 +10,11 @@
     "depends": ["crm", "base_multicompany_reporting_currency"],
     "website": "https://github.com/OCA/crm",
     "data": ["views/crm_lead_views.xml"],
+    "assets": {
+        "web.assets_backend": [
+            "crm_multicompany_reporting_currency/static/src/js/**/*.js",
+        ],
+    },
     "installable": True,
     "maintainers": ["yankinmax"],
 }

--- a/crm_multicompany_reporting_currency/models/crm_lead.py
+++ b/crm_multicompany_reporting_currency/models/crm_lead.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import api, fields, models
+from odoo.fields import Date
 
 
 class CrmLead(models.Model):
@@ -36,6 +37,15 @@ class CrmLead(models.Model):
         index=True,
         readonly=True,
     )
+
+    # technical field to be used in sum_field options on kanban
+    current_company_currency = fields.Many2one(
+        "res.currency", compute="_compute_current_company_currency", readonly=True
+    )
+
+    def _compute_current_company_currency(self):
+        for lead in self:
+            lead.current_company_currency = self.env.company.currency_id
 
     @api.depends("company_currency")
     def _compute_multicompany_reporting_currency_id(self):
@@ -81,3 +91,33 @@ class CrmLead(models.Model):
             else:
                 to_amount = record.expected_revenue * record.currency_rate
             record.amount_multicompany_reporting_currency = to_amount
+
+    @api.model
+    def read_group(self, domain, fields, groupby, **kwargs):
+        # Override read_group to calculate the sum of the
+        # expected revenue in current company currency
+        current_company = self.env.company
+        result = super().read_group(
+            domain,
+            fields,
+            groupby,
+            **kwargs,
+        )
+        opportunities = self.env["crm.lead"]
+        for line in result:
+            if "__domain" in line:
+                opportunities = self.search(line["__domain"])
+
+            if "expected_revenue" in fields:
+                global_revenue = sum(
+                    opportunities.mapped(
+                        lambda opp: opp.company_currency._convert(
+                            opp.expected_revenue,
+                            current_company.currency_id,
+                            current_company,
+                            Date.today(),
+                        )
+                    )
+                )
+                line["expected_revenue"] = global_revenue
+        return result

--- a/crm_multicompany_reporting_currency/readme/CONTRIBUTORS.rst
+++ b/crm_multicompany_reporting_currency/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Maksym Yankin <maksym.yankin@camptocamp.com>
+* Italo Lopes <italo.lopes@camptocamp.com>

--- a/crm_multicompany_reporting_currency/static/description/index.html
+++ b/crm_multicompany_reporting_currency/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -405,12 +405,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
 <ul class="simple">
 <li>Maksym Yankin &lt;<a class="reference external" href="mailto:maksym.yankin&#64;camptocamp.com">maksym.yankin&#64;camptocamp.com</a>&gt;</li>
+<li>Italo Lopes &lt;<a class="reference external" href="mailto:italo.lopes&#64;camptocamp.com">italo.lopes&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/crm_multicompany_reporting_currency/static/src/js/views/kanban/kanban_column_progressbar.js
+++ b/crm_multicompany_reporting_currency/static/src/js/views/kanban/kanban_column_progressbar.js
@@ -1,0 +1,27 @@
+odoo.define(
+    "crm_multicompany_reporting_currency.kanban_column_progressbar",
+    function (require) {
+        "use strict";
+
+        const KanbanColumnProgressBar = require("web.KanbanColumnProgressBar");
+        const session = require("web.session");
+
+        KanbanColumnProgressBar.include({
+            /**
+             * Override to replace sum_field options currency_field with current_company_currency.
+             * This gives a possibility to change the currency displayed on progressbar
+             */
+            init: function (parent, options, columnState) {
+                this._super.apply(this, arguments);
+                var companyCurrency =
+                    columnState.progressBarValues.company_currency_field;
+                if (companyCurrency && columnState.data.length) {
+                    this.currency =
+                        session.currencies[
+                            columnState.data[0].data[companyCurrency].res_id
+                        ];
+                }
+            },
+        });
+    }
+);

--- a/crm_multicompany_reporting_currency/views/crm_lead_views.xml
+++ b/crm_multicompany_reporting_currency/views/crm_lead_views.xml
@@ -52,4 +52,20 @@
         </field>
     </record>
 
+    <record id="crm_lead_view_kanban_multi_currency" model="ir.ui.view">
+        <field name="name">crm.lead.view.kanban.multi.currency</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.crm_case_kanban_view_leads" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_currency']" position="after">
+                <field name="current_company_currency" />
+            </xpath>
+            <progressbar position="attributes">
+                <attribute
+                    name="company_currency_field"
+                >current_company_currency</attribute>
+            </progressbar>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
* Use the current company currency when summing amounts on CRM kanban.

If we use more than one currency on `crm.lead`, odoo will sum the `expected_revenue` ignoring the currency : 
USD 50,00 + EUR 50,00 = USD 100,00 (odoo takes the first record on kanban view)

With this update, we will use the `current_company_currency` : 
Company currency = BRL
(1 USD = 1.5 BRL and 1 EUR = 2 BRL)

USD 50,00 = 75,00 BRL
EUR 50,00 = 100,00 BRL

We display on kanban progress bar `BRL 175,00`


The second commit is the same than here: https://github.com/OCA/crm/pull/642

