### PR TITLE
[16.0][FIX] crm_salesperson_planner: add title to button in planner visit view

### DIFF
--- a/crm_salesperson_planner/views/crm_salesperson_planner_visit_views.xml
+++ b/crm_salesperson_planner/views/crm_salesperson_planner_visit_views.xml
@@ -24,18 +24,21 @@
                     type="object"
                     attrs="{'invisible': [('state', 'not in', ['cancel','incident', 'done'])]}"
                     icon="fa-undo"
+                    title="Draft"
                 />
                 <button
                     name="action_confirm"
                     type="object"
                     icon="fa-calendar text-success"
                     attrs="{'invisible': [('state', '!=', 'draft')]}"
+                    title="Confirm"
                 />
                 <button
                     name="action_done"
                     type="object"
                     icon="fa-check"
                     attrs="{'invisible': [('state', '!=', 'confirm')]}"
+                    title="Done"
                 />
                 <button
                     name="%(crm_salesperson_planner_visit_close_wiz_action)d"


### PR DESCRIPTION
This PR doesn't modify the behavior but removes a warning.

Adding a title to buttons removes the following warning:
`WARNING ? odoo.addons.base.models.ir_ui_view: A button with icon attribute (fa-calendar text-success) must have title in its tag, parents, descendants or have text`