### PR TITLE
[18.0][FIX]crm_lead_to_task: Fix access right error to ir_act_window

### DIFF
--- a/crm_lead_to_task/models/crm_lead.py
+++ b/crm_lead_to_task/models/crm_lead.py
@@ -86,9 +86,9 @@ class CrmLead(models.Model):
                 self.company_id.crm_force_project_id
             )
         else:
-            action = self.env.ref(
+            action = self.env["ir.actions.act_window"]._for_xml_id(
                 "crm_lead_to_task.crm_lead_convert2task_action"
-            ).read()[0]
+            )
             action["context"] = {"default_lead_id": self.id}
 
         return action


### PR DESCRIPTION
Tested on Runboat : before this commit, the user has an access right message...

<img width="1713" height="707" alt="Capture d’écran du 2025-11-03 15-46-16" src="https://github.com/user-attachments/assets/e9c766db-8fce-41de-9388-14942ce47838" />

it looks like nobody saw this one... ?
