### PR TITLE
[18.0][IMP] crm_security_group: Add "User: Team Documents Only" group

### DIFF
--- a/crm_security_group/README.rst
+++ b/crm_security_group/README.rst
@@ -28,9 +28,9 @@ CRM Only Security Groups
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module adds new security options to CRM by creating 3 groups (Own
-Documents Only, All Documents and Administrator) to separate Sales and
-CRM apps permissions
+This module adds new security options to CRM by creating 4 groups (Own
+Documents Only, Team Documents Only, All Documents and Administrator) to
+separate Sales and CRM apps permissions
 
 **Table of contents**
 
@@ -40,8 +40,8 @@ CRM apps permissions
 Known issues / Roadmap
 ======================
 
-- Remove sale_crm dependency (now is not possible), maybe split this
-  part in other addon
+-  Remove sale_crm dependency (now is not possible), maybe split this
+   part in other addon
 
 Bug Tracker
 ===========
@@ -64,9 +64,9 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Víctor Martínez
+   -  Víctor Martínez
 
 Maintainers
 -----------

--- a/crm_security_group/__manifest__.py
+++ b/crm_security_group/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "CRM Only Security Groups",
     "summary": "Add new group in Sales to show only CRM",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "category": "Customer Relationship Management",
     "website": "https://github.com/OCA/crm",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/crm_security_group/i18n/crm_security_group.pot
+++ b/crm_security_group/i18n/crm_security_group.pot
@@ -32,3 +32,8 @@ msgstr ""
 #: model:res.groups,name:crm_security_group.group_crm_own_leads
 msgid "User: Own Documents Only"
 msgstr ""
+
+#. module: crm_security_group
+#: model:res.groups,name:crm_security_group.group_crm_team_leads
+msgid "User: Team Documents Only"
+msgstr ""

--- a/crm_security_group/i18n/es.po
+++ b/crm_security_group/i18n/es.po
@@ -35,3 +35,8 @@ msgstr "Usuario: Todos los documentos"
 #: model:res.groups,name:crm_security_group.group_crm_own_leads
 msgid "User: Own Documents Only"
 msgstr "Usuario: Mostrar solo documentos propios"
+
+#. module: crm_security_group
+#: model:res.groups,name:crm_security_group.group_crm_team_leads
+msgid "User: Team Documents Only"
+msgstr "Usuario: Mostrar solo documentos del equipo"

--- a/crm_security_group/migrations/18.0.1.1.0/noupdate_changes.xml
+++ b/crm_security_group/migrations/18.0.1.1.0/noupdate_changes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="group_crm_all_leads" model="res.groups">
+        <field
+            name="implied_ids"
+            eval="[(6, 0, [ref('crm_security_group.group_crm_team_leads')])]"
+        />
+    </record>
+</odoo>

--- a/crm_security_group/migrations/18.0.1.1.0/post-migration.py
+++ b/crm_security_group/migrations/18.0.1.1.0/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2025 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "crm_security_group", "migrations/18.0.1.1.0/noupdate_changes.xml"
+    )

--- a/crm_security_group/readme/DESCRIPTION.md
+++ b/crm_security_group/readme/DESCRIPTION.md
@@ -1,3 +1,3 @@
-This module adds new security options to CRM by creating 3 groups (Own
-Documents Only, All Documents and Administrator) to separate Sales and
-CRM apps permissions
+This module adds new security options to CRM by creating 4 groups (Own
+Documents Only, Team Documents Only, All Documents and Administrator)
+to separate Sales and CRM apps permissions

--- a/crm_security_group/security/security.xml
+++ b/crm_security_group/security/security.xml
@@ -9,12 +9,20 @@
         <field name="category_id" ref="crm_security_group.module_category_crm_crm" />
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]" />
     </record>
+    <record id="group_crm_team_leads" model="res.groups">
+        <field name="name">User: Team Documents Only</field>
+        <field name="category_id" ref="crm_security_group.module_category_crm_crm" />
+        <field
+            name="implied_ids"
+            eval="[(4, ref('crm_security_group.group_crm_own_leads'))]"
+        />
+    </record>
     <record id="group_crm_all_leads" model="res.groups">
         <field name="name">User: All Documents</field>
         <field name="category_id" ref="crm_security_group.module_category_crm_crm" />
         <field
             name="implied_ids"
-            eval="[(4, ref('crm_security_group.group_crm_own_leads'))]"
+            eval="[(4, ref('crm_security_group.group_crm_team_leads'))]"
         />
     </record>
     <record id="group_crm_manager" model="res.groups">
@@ -39,6 +47,17 @@
             <field
                 name="groups"
                 eval="[(4, ref('crm_security_group.group_crm_own_leads'))]"
+            />
+        </record>
+        <record id="crm_team_rule" model="ir.rule">
+            <field name="name">Team Leads</field>
+            <field name="model_id" ref="crm.model_crm_lead" />
+            <field name="domain_force">
+                ['|', ('team_id','in',user.crm_team_ids.ids),('message_partner_ids','in',[user.partner_id.id])]
+            </field>
+            <field
+                name="groups"
+                eval="[(4, ref('crm_security_group.group_crm_team_leads'))]"
             />
         </record>
         <record id="crm_see_all" model="ir.rule">

--- a/crm_security_group/static/description/index.html
+++ b/crm_security_group/static/description/index.html
@@ -370,9 +370,9 @@ ul.auto-toc {
 !! source digest: sha256:ff827f2c5570d1bb578f6a4d533f423854d8a9852c19f93135d98e8844226261
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/crm/tree/18.0/crm_security_group"><img alt="OCA/crm" src="https://img.shields.io/badge/github-OCA%2Fcrm-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/crm-18-0/crm-18-0-crm_security_group"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/crm&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module adds new security options to CRM by creating 3 groups (Own
-Documents Only, All Documents and Administrator) to separate Sales and
-CRM apps permissions</p>
+<p>This module adds new security options to CRM by creating 4 groups (Own
+Documents Only, Team Documents Only, All Documents and Administrator) to
+separate Sales and CRM apps permissions</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/crm_security_group/tests/test_crm_security.py
+++ b/crm_security_group/tests/test_crm_security.py
@@ -4,6 +4,7 @@
 from odoo.exceptions import AccessError
 from odoo.tests import Form, new_test_user
 from odoo.tests.common import users
+from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -41,6 +42,7 @@ class TestCrmSecurity(BaseCommon):
         )
 
     @users("crm_user")
+    @mute_logger("odoo.addons.base.models.ir_model", "odoo.models")
     def test_user_crm_only(self):
         items = self.env["ir.ui.menu"]._visible_menu_ids()
         self.assertIn(self.crm_menu.id, items)
@@ -54,6 +56,7 @@ class TestCrmSecurity(BaseCommon):
         crm_lead_form.save()
 
     @users("sale_user")
+    @mute_logger("odoo.addons.base.models.ir_model", "odoo.models")
     def test_user_sale(self):
         items = self.env["ir.ui.menu"]._visible_menu_ids()
         self.assertNotIn(self.crm_menu.id, items)
@@ -74,6 +77,7 @@ class TestCrmSecurity(BaseCommon):
         sale_order_form.save()
 
     @users("crm_sale_user")
+    @mute_logger("odoo.addons.base.models.ir_model", "odoo.models")
     def test_user_crm_sale(self):
         items = self.env["ir.ui.menu"]._visible_menu_ids()
         self.assertIn(self.crm_menu.id, items)


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/crm/pull/702

Add "User: Team Documents Only" group 

Please @pedrobaeza and @christian-ramos-tecnativa can you review it?

@Tecnativa TT59031