### PR TITLE
[17.0] [FIX] crm_salesperson_planner: rescheduled date must be able to be invisible

### DIFF
--- a/crm_salesperson_planner/wizards/crm_salesperson_planner_visit_close_wiz_view.xml
+++ b/crm_salesperson_planner/wizards/crm_salesperson_planner_visit_close_wiz_view.xml
@@ -18,11 +18,11 @@
                     <field name="reschedule" invisible="not allow_reschedule" />
                     <field
                         name="new_date"
-                        invisible="not allow_reschedule and not reschedule"
+                        invisible="not allow_reschedule or not reschedule"
                     />
                     <field
                         name="new_sequence"
-                        invisible="not allow_reschedule and not reschedule"
+                        invisible="not allow_reschedule or not reschedule"
                     />
                     <field name="require_image" invisible="1" />
                     <field


### PR DESCRIPTION
An error was detected in [this migration](https://github.com/OCA/crm/pull/585/commits/0e43619d1402d61586328b33ed56d547b593f7ae#diff-ca48d9e6f4024375c0d400c920e74ec4b288142318526bc0ca55e0ff3e38921aR19-R26)

This makes the "New Date" and "Sequence" fields to be always visible, when they should be hidden if the close reasons does not need to be rescheduled

In version 17:
<img width="1694" height="596" alt="507194149-b0b3eb19-63f5-4d3e-8ce9-9203216bbadf" src="https://github.com/user-attachments/assets/837e3ee6-da26-49e8-adaa-dc632f7a5fb6" />

In version 16 or minor:
<img width="1778" height="532" alt="507198134-f82a3d09-1ea4-42dd-b7ee-513c5e0d7624" src="https://github.com/user-attachments/assets/ea83fb22-eb49-4f4d-87c0-54cb171ab790" />

T-8956