### PR TITLE
[17.0] [FIX] crm_phonecall: Permission error in action

### DIFF
--- a/crm_phonecall/models/crm_lead.py
+++ b/crm_phonecall/models/crm_lead.py
@@ -25,7 +25,9 @@ class CrmLead(models.Model):
 
     def button_open_phonecall(self):
         self.ensure_one()
-        action_dict = self.env["ir.actions.act_window"]._for_xml_id("crm_phonecall.crm_case_categ_phone_incoming0")
+        action_dict = self.env["ir.actions.act_window"]._for_xml_id(
+            "crm_phonecall.crm_case_categ_phone_incoming0"
+        )
         action_dict["context"] = safe_eval(action_dict.get("context", "{}"))
         action_dict["context"].update(
             {

--- a/crm_phonecall/models/crm_lead.py
+++ b/crm_phonecall/models/crm_lead.py
@@ -25,8 +25,7 @@ class CrmLead(models.Model):
 
     def button_open_phonecall(self):
         self.ensure_one()
-        action = self.env.ref("crm_phonecall.crm_case_categ_phone_incoming0")
-        action_dict = action.read()[0] if action else {}
+        action_dict = self.env["ir.actions.act_window"]._for_xml_id("crm_phonecall.crm_case_categ_phone_incoming0")
         action_dict["context"] = safe_eval(action_dict.get("context", "{}"))
         action_dict["context"].update(
             {


### PR DESCRIPTION
Viewing calls from the CRM Lead results in a permissions error caused by the action being read.
The issue has been resolved by updating to the _for_xml_id() format, which is the current standard in this version.

- Impacted versions:

17.0

- Steps to reproduce:

Go to the CRM -> one record -> open form view
Click the Call SmartButton with a user who is not an administrator and does not have Settings permissions.

