### PR TITLE
[18.0][IMP] crm_phonecall: Add computed partner city/state/zip fields

### DIFF
--- a/crm_phonecall/models/crm_phonecall.py
+++ b/crm_phonecall/models/crm_phonecall.py
@@ -61,6 +61,9 @@ class CrmPhonecall(models.Model):
     )
     partner_phone = fields.Char(string="Phone")
     partner_mobile = fields.Char("Mobile")
+    partner_city = fields.Char(related="partner_id.city")
+    partner_zip = fields.Char(related="partner_id.zip")
+    partner_state = fields.Char(related="partner_id.state_id.name")
     priority = fields.Selection(
         selection=[("0", "Low"), ("1", "Normal"), ("2", "High")],
         default="1",

--- a/crm_phonecall/report/crm_phonecall_report.py
+++ b/crm_phonecall/report/crm_phonecall_report.py
@@ -47,6 +47,9 @@ class CrmPhonecallReport(models.Model):
     partner_id = fields.Many2one(
         comodel_name="res.partner", string="Partner", readonly=True
     )
+    partner_zip = fields.Char("ZIP", readonly=True)
+    partner_state = fields.Char("State", readonly=True)
+    partner_city = fields.Char("City", readonly=True)
     company_id = fields.Many2one(
         comodel_name="res.company", string="Company", readonly=True
     )
@@ -56,7 +59,7 @@ class CrmPhonecallReport(models.Model):
     def _select(self):
         select_str = """
             select
-                id,
+                c.id,
                 c.date_open as opening_date,
                 c.date_closed as date_closed,
                 c.state,
@@ -73,13 +76,18 @@ class CrmPhonecallReport(models.Model):
                   c.date_closed-c.create_date))/(3600*24) as delay_close,
                 extract(
                   'epoch' from (
-                  c.date_open-c.create_date))/(3600*24) as delay_open
+                  c.date_open-c.create_date))/(3600*24) as delay_open,
+                p.zip AS partner_zip,
+                p.city AS partner_city,
+                s.name AS partner_state
            """
         return select_str
 
     def _from(self):
         from_str = """
             from crm_phonecall c
+            LEFT JOIN res_partner p ON c.partner_id = p.id
+            LEFT JOIN res_country_state s ON p.state_id = s.id
         """
         return from_str
 

--- a/crm_phonecall/views/crm_phonecall_view.xml
+++ b/crm_phonecall/views/crm_phonecall_view.xml
@@ -142,7 +142,7 @@
                                 />
                                 <b>min(s)</b>
                             </div>
-                            <field name="partner_id" />
+                            <field name="partner_id" context="{'show_address': 1}" />
                             <field name="partner_mobile" />
                             <field
                                 context="{'opportunity_id': opportunity_id}"
@@ -190,6 +190,9 @@
                 <field name="date" />
                 <field name="name" />
                 <field name="partner_id" />
+                <field name="partner_state" optional="hide" readonly="1" />
+                <field name="partner_zip" optional="hide" readonly="1" />
+                <field name="partner_city" optional="hide" readonly="1" />
                 <field column_invisible="1" name="partner_phone" />
                 <field column_invisible="1" name="partner_mobile" />
                 <field
@@ -239,6 +242,9 @@
             >
                 <field name="name" />
                 <field name="partner_id" />
+                <field name="partner_state" />
+                <field name="partner_zip" />
+                <field name="partner_city" />
             </calendar>
         </field>
     </record>
@@ -285,6 +291,22 @@
                 <separator />
                 <filter date="date" name="date" string="Date" />
                 <separator />
+                <filter
+                    domain="[('partner_city', '!=', False)]"
+                    name="has_city"
+                    string="City"
+                />
+                <filter
+                    domain="[('partner_state', '!=', False)]"
+                    name="has_state"
+                    string="State"
+                />
+                <filter
+                    domain="[('partner_zip', '!=', False)]"
+                    name="has_zip"
+                    string="ZIP"
+                />
+                <separator />
                 <field name="partner_id" operator="child_of" />
                 <field name="user_id" />
                 <field name="opportunity_id" />
@@ -321,6 +343,21 @@
                         help="Calls by status"
                         name="groupby_state"
                         string="State"
+                    />
+                    <filter
+                        context="{'group_by': 'partner_city'}"
+                        name="groupby_city"
+                        string="City"
+                    />
+                    <filter
+                        context="{'group_by': 'partner_state'}"
+                        name="groupby_state2"
+                        string="State"
+                    />
+                    <filter
+                        context="{'group_by': 'partner_zip'}"
+                        name="groupby_zip"
+                        string="ZIP"
                     />
                 </group>
             </search>

--- a/crm_phonecall/wizard/crm_phonecall_to_phonecall_view.xml
+++ b/crm_phonecall/wizard/crm_phonecall_to_phonecall_view.xml
@@ -8,7 +8,11 @@
                 <group>
                     <group>
                         <field name="action" />
-                        <field readonly="1" name="partner_id" />
+                        <field
+                            readonly="1"
+                            name="partner_id"
+                            context="{'show_address': 1}"
+                        />
                         <field groups="sales_team.group_sale_salesman" name="team_id" />
                     </group>
                     <group>


### PR DESCRIPTION
@HaraldPanten @ValentinVinagre 

- This PR replaces a previous implementation that was reverted #663 . It introduces the corrected and reviewed implementation.
- Local `.po` files were not being properly loaded by the module despite several attempts, so translations are intentionally deferred.  Spanish (es) and Catalan (ca) translations will be added later via Weblate.

[T-9197]