### PR TITLE
[19.0][FIX] update pre-commit-config

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,9 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.35
+_commit: v1.42
 _src_path: git+https://github.com/OCA/oca-addons-repo-template
 additional_ruff_rules: []
-ci: GitHub
 convert_readme_fragments_to_markdown: true
-enable_checklog_odoo: true
+enable_checklog_odoo: false
 generate_requirements_txt: true
 github_check_license: true
 github_ci_extra_env: {}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+
 name: pre-commit
 
 on:
@@ -16,7 +17,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: '.pre-commit-config.yaml'
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,6 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
-    env:
-      OCA_ENABLE_CHECKLOG_ODOO: "1"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,6 +63,13 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
+      - name: Upload screenshots from JS tests
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: Screenshots of failed JS tests - ${{ matrix.name }}${{ join(matrix.include) }}
+          path: /tmp/odoo_tests/${{ env.PGDATABASE }}
+          if-no-files-found: ignore
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: python3.12
   node: "22.9.0"
 repos:
   - repo: local
@@ -38,12 +38,17 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+      - id: obsolete dotfiles
+        name: obsolete dotfiles
+        entry: found obsolete files; remove them
+        files: '^(\.travis\.yml|\.t2d\.yml|CONTRIBUTING\.md|\.prettierrc\.yml|\.eslintrc\.yml)$'
+        language: fail
   - repo: https://github.com/sbidoul/whool
     rev: v1.3
     hooks:
       - id: whool-init
   - repo: https://github.com/oca/maintainer-tools
-    rev: f9b919b9868143135a9c9cb03021089cabba8223
+    rev: 71aa4caec15e8c1456b4da19e9f39aa0aa7377a9
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -60,7 +65,7 @@ repos:
           - --convert-fragments-to-markdown
       - id: oca-gen-external-dependencies
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
-    rev: v0.1.6
+    rev: v0.1.7
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po
@@ -117,13 +122,13 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.14.13
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.3.15
+    rev: v10.0.0
     hooks:
       - id: pylint_odoo
         name: pylint with optional checks

--- a/.pylintrc
+++ b/.pylintrc
@@ -92,20 +92,11 @@ enable=anomalous-backslash-in-string,
     no-write-in-compute,
     # messages that do not cause the lint step to fail
     consider-merging-classes-inherited,
-    create-user-wo-reset-password,
-    dangerous-filter-wo-user,
     deprecated-module,
-    file-not-used,
     invalid-commit,
-    missing-manifest-dependency,
-    missing-newline-extrafiles,
     missing-readme,
-    no-utf8-coding-comment,
     odoo-addons-relative-import,
-    old-api7-method-defined,
     redefined-builtin,
-    too-complex,
-    unnecessary-utf8-coding-comment,
     manifest-external-assets
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 
+[![Support the OCA](https://odoo-community.org/readme-banner-image)](https://odoo-community.org/get-involved?utm_source=repo-readme)
+
+# crm
 [![Runboat](https://img.shields.io/badge/runboat-Try%20me-875A7B.png)](https://runboat.odoo-community.org/builds?repo=OCA/crm&target_branch=19.0)
 [![Pre-commit Status](https://github.com/OCA/crm/actions/workflows/pre-commit.yml/badge.svg?branch=19.0)](https://github.com/OCA/crm/actions/workflows/pre-commit.yml?query=branch%3A19.0)
 [![Build Status](https://github.com/OCA/crm/actions/workflows/test.yml/badge.svg?branch=19.0)](https://github.com/OCA/crm/actions/workflows/test.yml?query=branch%3A19.0)
@@ -6,8 +9,6 @@
 [![Translation Status](https://translation.odoo-community.org/widgets/crm-19-0/-/svg-badge.svg)](https://translation.odoo-community.org/engage/crm-19-0/?utm_source=widget)
 
 <!-- /!\ do not modify above this line -->
-
-# crm
 
 crm
 

--- a/crm_claim/models/crm_claim.py
+++ b/crm_claim/models/crm_claim.py
@@ -83,10 +83,9 @@ class CrmClaim(models.Model):
     )
     company_id = fields.Many2one(
         comodel_name="res.company",
-        string="Company",
         default=lambda self: self.env.company,
     )
-    partner_id = fields.Many2one(comodel_name="res.partner", string="Partner")
+    partner_id = fields.Many2one(comodel_name="res.partner")
     email_cc = fields.Text(
         string="Watchers Emails",
         help="These email addresses will be added to the CC field of all "
@@ -99,7 +98,6 @@ class CrmClaim(models.Model):
     partner_phone = fields.Char(string="Phone")
     stage_id = fields.Many2one(
         comodel_name="crm.claim.stage",
-        string="Stage",
         tracking=3,
         default=lambda self: self._get_default_stage_id(),
         domain="['|', ('team_ids', '=', team_id), ('case_default', '=', True)]",

--- a/crm_claim/report/crm_claim_report.py
+++ b/crm_claim/report/crm_claim_report.py
@@ -15,14 +15,13 @@ class CrmClaimReport(models.Model):
     _auto = False
     _description = "CRM Claim Report"
 
-    user_id = fields.Many2one(comodel_name="res.users", string="User")
-    team_id = fields.Many2one(comodel_name="crm.team", string="Team")
+    user_id = fields.Many2one(comodel_name="res.users")
+    team_id = fields.Many2one(comodel_name="crm.team")
     nbr_claims = fields.Integer(
         string="# of Claims",
     )
     company_id = fields.Many2one(
         comodel_name="res.company",
-        string="Company",
     )
     create_date = fields.Datetime(index=True)
     claim_date = fields.Datetime()
@@ -34,7 +33,6 @@ class CrmClaimReport(models.Model):
     )
     stage_id = fields.Many2one(
         comodel_name="crm.claim.stage",
-        string="Stage",
         domain="[('team_ids','=',team_id)]",
     )
     categ_id = fields.Many2one(
@@ -43,7 +41,6 @@ class CrmClaimReport(models.Model):
     )
     partner_id = fields.Many2one(
         comodel_name="res.partner",
-        string="Partner",
     )
     priority = fields.Selection(
         selection=[("0", "Low"), ("1", "Normal"), ("2", "High")]

--- a/crm_lead_to_task/wizard/crm_lead_convert2task.py
+++ b/crm_lead_to_task/wizard/crm_lead_convert2task.py
@@ -19,10 +19,8 @@ class CrmLeadConvert2Task(models.TransientModel):
             result["lead_id"] = lead_id
         return result
 
-    lead_id = fields.Many2one(
-        comodel_name="crm.lead", string="Lead", domain=[("type", "=", "lead")]
-    )
-    project_id = fields.Many2one(comodel_name="project.project", string="Project")
+    lead_id = fields.Many2one(comodel_name="crm.lead", domain=[("type", "=", "lead")])
+    project_id = fields.Many2one(comodel_name="project.project")
 
     def action_lead_to_project_task(self):
         return self.lead_id._action_create_and_open_task(self.project_id)

--- a/crm_lead_vat/views/crm_lead_views.xml
+++ b/crm_lead_vat/views/crm_lead_views.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="crm_lead_view_form" model="ir.ui.view">
         <field name="model">crm.lead</field>

--- a/crm_location/models/crm_lead.py
+++ b/crm_location/models/crm_lead.py
@@ -11,7 +11,6 @@ class CrmLead(models.Model):
 
     location_id = fields.Many2one(
         comodel_name="res.city.zip",
-        string="Location",
         index="btree",
         help="Use the city name or the zip code to search the location",
         compute="_compute_location_id",

--- a/crm_project_create/models/crm_lead.py
+++ b/crm_project_create/models/crm_lead.py
@@ -7,4 +7,4 @@ from odoo import fields, models
 class CrmLead(models.Model):
     _inherit = "crm.lead"
 
-    project_id = fields.Many2one("project.project", string="Project")
+    project_id = fields.Many2one(comodel_name="project.project")

--- a/srm/models/crm_lead.py
+++ b/srm/models/crm_lead.py
@@ -10,7 +10,7 @@ class CrmLead(models.Model):
     _inherit = "crm.lead"
 
     user_id = fields.Many2one(string="Responsible")
-    team_id = fields.Many2one(string="Team")
+    team_id = fields.Many2one()
 
     request_type = fields.Selection(
         selection=[

--- a/srm/models/purchase_order.py
+++ b/srm/models/purchase_order.py
@@ -9,7 +9,6 @@ class PurchaseOrder(models.Model):
 
     opportunity_id = fields.Many2one(
         comodel_name="crm.lead",
-        string="Opportunity",
         check_company=True,
         domain="""
             [


### PR DESCRIPTION
The update to pre-commit-config resolves the issue with the command, which appears to be outdated due to the change in version 19.0 to the "user_ids" attribute of the "ir.filters" base model. This attribute has changed compared to version 18.0, where it was "user_id". The commit showing this change can be found here: https://github.com/odoo/odoo/commit/414e55cf7c3971a7ba0a7c96855db4c23e77a5c4