### PR TITLE
[16.0][FIX] crm_date_deadline_required: fix usability issue on Kanban quick create

### DIFF
--- a/crm_date_deadline_required/__init__.py
+++ b/crm_date_deadline_required/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/crm_date_deadline_required/models/__init__.py
+++ b/crm_date_deadline_required/models/__init__.py
@@ -1,0 +1,1 @@
+from . import crm_lead

--- a/crm_date_deadline_required/models/crm_lead.py
+++ b/crm_date_deadline_required/models/crm_lead.py
@@ -1,0 +1,23 @@
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class CrmLead(models.Model):
+    _inherit = "crm.lead"
+
+    @api.constrains("date_deadline", "type")
+    def _check_date_deadline_required(self):
+        for record in self:
+            if record.type == "opportunity" and not record.date_deadline:
+                raise ValidationError(
+                    _("The expected closing date is required for opportunities.")
+                )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("type") == "opportunity" and not vals.get("date_deadline"):
+                raise ValidationError(
+                    _("The expected closing date is required for opportunities.")
+                )
+        return super().create(vals_list)

--- a/crm_date_deadline_required/tests/test_crm_date_deadline_required.py
+++ b/crm_date_deadline_required/tests/test_crm_date_deadline_required.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Moduon Team S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
 
+from odoo.exceptions import ValidationError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
@@ -11,30 +12,34 @@ class TestCRMDateDeadlineRequired(TransactionCase):
         super().setUpClass()
 
     def test_crm_date_deadline_required_opportunity(self):
-        """Check date_deadline required in opportunity in default form"""
+        """Check date_deadline is required in opportunity default form."""
         opportunity_form = Form(
             self.env["crm.lead"].with_context(default_type="opportunity")
         )
         opportunity_form.name = "Test Opportunity"
+        # The Form object raises AssertionError for XML required fields
+        # before the server-side ValidationError can be triggered.
         with self.assertRaises(AssertionError):
             opportunity_form.save()
         opportunity_form.date_deadline = "2025-01-01"
         opportunity_form.save()
 
     def test_crm_date_deadline_required_opportunity_quick_create(self):
-        """Check date_deadline required in opportunity in quick create form"""
-        opportunity_quick_create_form = Form(
-            self.env["crm.lead"].with_context(default_type="opportunity"),
-            "crm.quick_create_opportunity_form",
-        )
-        opportunity_quick_create_form.name = "Test Opportunity Quick Create"
-        with self.assertRaises(AssertionError):
-            opportunity_quick_create_form.save()
-        opportunity_quick_create_form.date_deadline = "2025-01-01"
-        opportunity_quick_create_form.save()
+        """Check date_deadline is required via server validation for quick create."""
+        # We test the server constraint directly because the field
+        # was removed from the quick create view to fix the OWL UI bug.
+        with self.assertRaises(ValidationError):
+            self.env["crm.lead"].with_context(default_type="opportunity").create(
+                {
+                    "name": "Test Opportunity Quick Create",
+                    "type": "opportunity",
+                    # We omit date_deadline to trigger the Python ValidationError
+                }
+            )
 
     def test_crm_date_deadline_required_lead(self):
-        """Check date_deadline not required in lead in default form"""
+        """Check date_deadline is not required for lead types."""
         lead_form = Form(self.env["crm.lead"].with_context(default_type="lead"))
         lead_form.name = "Test Lead"
+        # Should save without errors as it's not an opportunity
         lead_form.save()

--- a/crm_date_deadline_required/views/crm_lead_view.xml
+++ b/crm_date_deadline_required/views/crm_lead_view.xml
@@ -14,17 +14,4 @@
             </xpath>
         </field>
     </record>
-    <record id="quick_create_opportunity_form_inherit" model="ir.ui.view">
-        <field name="name">Date deadline required quick create form</field>
-        <field name="model">crm.lead</field>
-        <field name="inherit_id" ref="crm.quick_create_opportunity_form" />
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='phone']" position="after">
-                <field
-                    name="date_deadline"
-                    attrs="{'required': [('type', '=', 'opportunity')]}"
-                />
-            </xpath>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
In Odoo 16.0, adding a date field to the Kanban Quick Create form causes the form to close prematurely when the datepicker loses focus due to the OWL component lifecycle. This commit moves the requirement logic to the backend to preserve usability while ensuring data integrity.

### Bug Description
As reported in #695, when using the `crm_date_deadline_required` module in Odoo 16.0, the Kanban "Quick Create" form closes automatically if the user interacts with the `date_deadline` field (DatePicker) before completing other fields. This is caused by the native OWL lifecycle in the Kanban view, which triggers a save/close event upon focus loss of date widgets.

### Solution
Since the framework's behavior in v16 makes it unstable to include a required date field directly in the Quick Create popover, this PR implements a more robust "Backend-First" approach:

1.  **Backend Validation**: Added `@api.constrains` and overrode the `create` method in `crm.lead` to ensure `date_deadline` is strictly mandatory for opportunities at the server level.
2.  **View Optimization**: Removed the `quick_create` view inheritance to prevent the UI crash/auto-close. 
3.  **Standard Workflow**: By enforcing the requirement in Python, if a user attempts to "Quick Create" an opportunity without a date, Odoo will trigger a `ValidationError`. The native web client then automatically redirects the user to the full form view with all previously entered data, where they can set the date without UI issues.

### Integrity
This change ensures that no opportunity can be created without a deadline through any channel (UI, API, or Import), while restoring a fluid workflow for sales teams using the Pipeline Kanban view.

Fixes #695