### PR TITLE
[19.0][FIX] srm: default request_type to customer

### DIFF
--- a/srm/models/crm_lead.py
+++ b/srm/models/crm_lead.py
@@ -17,6 +17,7 @@ class CrmLead(models.Model):
             ("customer", "Customer Lead"),
             ("supplier", "Supplier Lead"),
         ],
+        default="customer",
     )
     purchase_amount_total = fields.Monetary(
         compute="_compute_purchase_amount_total",


### PR DESCRIPTION
request_type was only ever set via a default_request_type context key on crm.crm_lead_action_pipeline's "New" button. Any lead created another way (website form, import, other integrations) got an empty request_type and was silently excluded from the Pipeline view, whose domain requires request_type = 'customer'.

Default the field itself to 'customer'. Context-set defaults still take precedence over field defaults, so the supplier RFQ flows (which set default_request_type='supplier' explicitly) are unaffected.