### PR TITLE
[19.0][FIX] crm_claim: Make claim description field full width

### DIFF
--- a/crm_claim/views/crm_claim_views.xml
+++ b/crm_claim/views/crm_claim_views.xml
@@ -63,7 +63,7 @@
                                 string="Claim/Action Description"
                                 groups="base.group_user"
                             >
-                                <field name="description" nolabel="1" />
+                                <field name="description" nolabel="1" colspan="2" />
                             </group>
                         </page>
                         <page string="Follow Up" groups="base.group_user">


### PR DESCRIPTION
Before
<img width="1528" height="501" alt="image" src="https://github.com/user-attachments/assets/848779ac-6a3b-460b-8a3a-b8d9b2253e99" />

After
<img width="3754" height="523" alt="image" src="https://github.com/user-attachments/assets/8721c77e-9074-4f10-b1de-5a3cecd369f1" />

@pedrobaeza can you review please

@Tecnativa
TT64340